### PR TITLE
Fix Ubuntu CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
+ARG VARIANT="hirsute"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+		// Use hirsute or bionic on local arm64/Apple Silicon.
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"rust": "latest"
+	}
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,11 @@ serde = "^1.0.133"
 serde_derive = "^1.0.133"
 toml = "^0.5.8"
 
+# fs
+tempfile = "^3.2.0"
+
 [dev-dependencies]
 # testing
-tempfile = "^3.2.0"
 walkdir = "^2.3.2"
 assert_cmd = "^2.0.2"
 pretty_assertions = "^1.0.0"

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -57,9 +57,7 @@ pub fn list(matches: &ArgMatches) {
     for dot in dots::find_all(&env) {
         let mut remote = String::new();
         if matches.is_present("origins") {
-            remote = dot
-                .origin()
-                .map_or(remote, |origin| format!(" => {}", origin.trim()));
+            remote = dot.origin()
         };
 
         println!("{name}{remote}", name = dot.package.package.name)

--- a/src/dot_package.rs
+++ b/src/dot_package.rs
@@ -29,7 +29,7 @@ impl DotPackage {
         let contents = match read_package(path.join("Dot.toml")) {
             Ok(contents) => contents,
             Err(err) => {
-                error!("Error reading Dot.toml:\nin {}\n{}", path, err);
+                error!("Error reading Dot.toml:\n{}", err);
                 return Err(format_err!("Error reading Dot.toml"));
             }
         };
@@ -37,7 +37,7 @@ impl DotPackage {
         let package = match parse_package(&contents) {
             Ok(package) => package,
             Err(err) => {
-                error!("Error parsing Dot.toml:\nin {}\n{}", path, err);
+                error!("Error parsing Dot.toml:\n{}", err);
                 return Err(format_err!("Error reading Dot.toml"));
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,13 @@
 extern crate camino;
 extern crate failure;
+extern crate tempfile;
 extern crate utils;
-
 #[macro_use]
 extern crate clap;
 extern crate dirs;
 extern crate env_logger;
 #[macro_use]
 extern crate log;
-
 #[macro_use]
 extern crate serde_derive;
 extern crate toml;

--- a/test_utils/src/test_dir.rs
+++ b/test_utils/src/test_dir.rs
@@ -2,7 +2,7 @@ use crate::Fixture;
 use camino::{Utf8Path, Utf8PathBuf};
 use tempfile::{tempdir, TempDir};
 use utils::fs::copy_dir;
-use utils::git::init_git_repo;
+use utils::git;
 
 pub struct TestDir {
     tmpdir: TempDir,
@@ -52,7 +52,13 @@ impl TestDir {
         fixture: &Fixture,
     ) -> Result<Utf8PathBuf, failure::Error> {
         let fixture_path = self.copy_fixture(fixture)?;
-        init_git_repo(&fixture_path)?;
+        git::init_repo(&fixture_path)?;
+
+        git::config(&fixture_path, "user.name", "webdesserts")?;
+        git::config(&fixture_path, "user.email", "test@webdesserts.com")?;
+
+        git::commit_all(&fixture_path, "initial commit")?;
+
         Ok(fixture_path)
     }
 }

--- a/tests/output/add_fail_with_missing_dot_toml.out
+++ b/tests/output/add_fail_with_missing_dot_toml.out
@@ -1,6 +1,5 @@
 [info] Adding {SRC_PATH}
 [info] Cloning...
 [error] Error reading Dot.toml:
-[error]   in {TMP_PATH}
 [error]   No such file or directory (os error 2)
 [error] Repo does not appear to be a Dot

--- a/tests/subcommand_add.rs
+++ b/tests/subcommand_add.rs
@@ -11,7 +11,7 @@ mod subcommand_add {
         let fixture_path = test_dir.setup_fixture_as_git_repo(&fixture)?;
         let dots_root = test_dir.dots_root();
 
-        let mut cmd = Command::cargo_bin("dots").unwrap();
+        let mut cmd = Command::cargo_bin("dots")?;
 
         cmd.arg("add")
             .arg(&fixture_path)
@@ -45,7 +45,7 @@ mod subcommand_add {
         fs::remove_file(&dot_toml_path)?;
         commit_all(&fixture_path, "remove Dot.toml")?;
 
-        let mut cmd = Command::cargo_bin("dots").unwrap();
+        let mut cmd = Command::cargo_bin("dots")?;
 
         cmd.arg("add")
             .arg(&fixture_path)

--- a/tests/subcommand_add.rs
+++ b/tests/subcommand_add.rs
@@ -33,10 +33,6 @@ mod subcommand_add {
         Ok(())
     }
 
-    /*
-     * @todo remove TMP_PATH from the output. It's an implementation detail and doesn't offer
-     * much help to the user.
-     */
     #[test]
     fn it_should_complain_if_there_is_no_dot_toml() -> TestResult {
         let test_dir = TestDir::new()?;
@@ -60,7 +56,6 @@ mod subcommand_add {
         let expected = format!(
             std::include_str!("output/add_fail_with_missing_dot_toml.out"),
             SRC_PATH = fixture_path,
-            TMP_PATH = dots_root.join(".tmp"),
         );
 
         output.assert_stderr_eq(expected).assert_fail_with_code(1);

--- a/tests/subcommand_list.rs
+++ b/tests/subcommand_list.rs
@@ -5,7 +5,7 @@ mod subcommand_list {
     #[test]
     fn it_should_list_nothing_by_default() -> TestResult {
         let test_dir = TestDir::new()?;
-        let mut cmd = Command::cargo_bin("dots").unwrap();
+        let mut cmd = Command::cargo_bin("dots")?;
         let output = cmd
             .arg("list")
             .arg("--dotsPath")

--- a/utils/src/git.rs
+++ b/utils/src/git.rs
@@ -1,71 +1,135 @@
 use camino::Utf8Path;
+use std::error::Error;
+use std::fmt;
 use std::io;
-use std::process::Command;
+use std::process::{Command, Output};
 
-pub fn init_git_repo<P>(path: P) -> Result<(), io::Error>
+#[derive(Debug)]
+pub struct GitError {
+    kind: GitErrorKind,
+}
+
+#[derive(Debug)]
+pub enum GitErrorKind {
+    GitNotFound,
+    Command(Output),
+    Io(io::Error),
+}
+
+impl Error for GitError {}
+
+impl GitError {
+    pub fn kind(&self) -> &GitErrorKind {
+        &self.kind
+    }
+}
+
+impl fmt::Display for GitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind() {
+            GitErrorKind::Io(err) => {
+                write!(f, "Git failed with the following Io error:\n{}", err)
+            }
+            GitErrorKind::Command(output) => {
+                let err = std::str::from_utf8(&output.stderr).unwrap();
+                let out = std::str::from_utf8(&output.stdout).unwrap();
+
+                write!(f, "Git exited with the following output\n{err}{out}",)
+            }
+            GitErrorKind::GitNotFound => {
+                write!(f, r#"Unable to find "git" command"#)
+            }
+        }
+    }
+}
+
+pub fn init_git_repo<P>(path: P) -> Result<(), GitError>
 where
     P: AsRef<Utf8Path>,
 {
     let path = path.as_ref();
 
-    Command::new("git")
-        .arg("init")
-        .current_dir(&path)
-        .output()?;
+    map_result(Command::new("git").arg("init").current_dir(&path).output())?;
 
     commit_all(&path, "initial commit")?;
 
     Ok(())
 }
 
-pub fn commit_all<P>(path: P, message: &str) -> Result<(), io::Error>
+pub fn commit_all<P>(path: P, message: &str) -> Result<(), GitError>
 where
     P: AsRef<Utf8Path>,
 {
     let path = path.as_ref();
 
-    Command::new("git")
-        .arg("add")
-        .arg("--all")
-        .current_dir(&path)
-        .output()?;
+    map_result(
+        Command::new("git")
+            .arg("add")
+            .arg("--all")
+            .current_dir(&path)
+            .output(),
+    )?;
 
-    Command::new("git")
-        .arg("commit")
-        .arg("-m")
-        .arg(format!("\"{message}\""))
-        .current_dir(&path)
-        .output()?;
+    map_result(
+        Command::new("git")
+            .arg("commit")
+            .arg("-m")
+            .arg(format!("\"{message}\""))
+            .current_dir(&path)
+            .output(),
+    )?;
 
     Ok(())
 }
 
-pub fn clone<P>(url: &str, dest: P) -> Result<(), io::Error>
+pub fn clone<P>(url: &str, dest: P) -> Result<(), GitError>
 where
     P: AsRef<Utf8Path>,
 {
-    Command::new("git")
-        .arg("clone")
-        .arg(url)
-        .arg(dest.as_ref())
-        .arg("--depth=1")
-        .output()?;
+    map_result(
+        Command::new("git")
+            .arg("clone")
+            .arg(url)
+            .arg(dest.as_ref())
+            .arg("--depth=1")
+            .output(),
+    )?;
 
     Ok(())
 }
 
-pub fn get_origin() -> Result<Option<String>, io::Error> {
-    let output = Command::new("git")
-        .arg("remote")
-        .arg("get-url")
-        .arg("origin")
-        .output()?;
+pub fn get_origin() -> Result<String, GitError> {
+    let output = map_result(
+        Command::new("git")
+            .arg("remote")
+            .arg("get-url")
+            .arg("origin")
+            .output(),
+    )?;
 
-    let string = if output.status.success() {
-        Some(String::from_utf8(output.stdout).expect("unable to convert origin output to utf8"))
-    } else {
-        None
-    };
+    let string = String::from_utf8(output.stdout).expect("unable to convert origin output to utf8");
 
     Ok(string)
+}
+
+fn map_result(result: Result<Output, io::Error>) -> Result<Output, GitError> {
+    match result {
+        Ok(output) => {
+            if output.status.success() {
+                Ok(output)
+            } else {
+                Err(GitError {
+                    kind: GitErrorKind::Command(output),
+                })
+            }
+        }
+        Err(err) => match err.kind() {
+            io::ErrorKind::NotFound => Err(GitError {
+                kind: GitErrorKind::GitNotFound,
+            }),
+            _ => Err(GitError {
+                kind: GitErrorKind::Io(err),
+            }),
+        },
+    }
 }

--- a/utils/src/git.rs
+++ b/utils/src/git.rs
@@ -43,7 +43,7 @@ impl fmt::Display for GitError {
     }
 }
 
-pub fn init_git_repo<P>(path: P) -> Result<(), GitError>
+pub fn init_repo<P>(path: P) -> Result<(), GitError>
 where
     P: AsRef<Utf8Path>,
 {
@@ -51,7 +51,23 @@ where
 
     map_result(Command::new("git").arg("init").current_dir(&path).output())?;
 
-    commit_all(&path, "initial commit")?;
+    Ok(())
+}
+
+pub fn config<P>(path: P, key: &str, value: &str) -> Result<(), GitError>
+where
+    P: AsRef<Utf8Path>,
+{
+    let path = path.as_ref();
+
+    map_result(
+        Command::new("git")
+            .arg("config")
+            .arg(key)
+            .arg(value)
+            .current_dir(&path)
+            .output(),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
This PR fixes an issue where our tests were failing during the Ubuntu ci run. This was happening because the Ubuntu ci by default does not have a configured `git config user.name` and `git config user.email`. This issue was hard to reproduce because although the ci environment didn't have these configured, the codespace environments would. To solve this issue we manually configure a test user every time we initialize a test repo.

In addition to the main fix this PR also contains two other improvements:
- We now use `tempfile` to generate and clean up our temporary dot install path during the initial clone. This will help ensure that tests do not conflict when running in parallel.
- We now have better error handling for all of our git errors. This makes it much easier to consume our git utils and will hopefully make it easier to understand these types of errors in the future.