### PR TITLE
Display Readme on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "dots"
 version = "0.4.0"
 edition = "2021"
 license = "MIT"
+readme = "Readme.md"
 description = "A cli for managing all your dot(file)s"
 authors = ["Michael Mullins <michael@webdesserts.com>"]
 repository = "https://github.com/webdesserts/dots-cli"


### PR DESCRIPTION
Added the `readme` field to cargo.toml. The reason I added this field is so that when you publish this crate to [crates.io](https://crates.io/crates/dots) your `Readme.md` file is used and shown since the convention of _README.md_ isn't being used.