### PR TITLE
Reverse Symlink Direction

### DIFF
--- a/fixtures/conflicting_dot/Dot.toml
+++ b/fixtures/conflicting_dot/Dot.toml
@@ -3,4 +3,4 @@ name = "conflicting_dot"
 authors = [ "Michael Mullins" ]
 
 [link]
-"shell/bashrc" = "~/.bashrc"
+"~/.bashrc" = "shell/bashrc"

--- a/fixtures/example_dot/Dot.toml
+++ b/fixtures/example_dot/Dot.toml
@@ -3,5 +3,5 @@ name = "example_dot"
 authors = [ "Michael Mullins" ]
 
 [link]
-"shell/bashrc" = "~/.bashrc"
-"shell/zshrc" = "~/.zshrc"
+"~/.bashrc" = "shell/bashrc"
+ "~/.zshrc" = "shell/zshrc"

--- a/fixtures/example_dot_with_directory/Dot.toml
+++ b/fixtures/example_dot_with_directory/Dot.toml
@@ -3,4 +3,4 @@ name = "example_dot_with_directory"
 authors = ["Michael Mullins"]
 
 [link]
-"bin" = "~/bin"
+"~/bin" = "bin"

--- a/fixtures/example_dot_with_link_added/Dot.toml
+++ b/fixtures/example_dot_with_link_added/Dot.toml
@@ -3,6 +3,6 @@ name = "example_dot"
 authors = ["Michael Mullins"]
 
 [link]
-"shell/bashrc" = "~/.bashrc"
-"shell/bash_profile" = "~/.bash_profile"
-"shell/zshrc" = "~/.zshrc"
+"~/.bashrc" = "shell/bashrc" 
+"~/.bash_profile" = "shell/bash_profile"
+"~/.zshrc" = "shell/zshrc"

--- a/fixtures/example_dot_with_multi_link/Dot.toml
+++ b/fixtures/example_dot_with_multi_link/Dot.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example_dot"
+authors = ["Michael Mullins"]
+
+[link]
+"~/.bashrc" = "shell/bashrc" 
+"~/.bash_profile" = "shell/bashrc"
+"~/.zshrc" = "shell/zshrc"

--- a/fixtures/example_dot_with_multi_link/shell/bashrc
+++ b/fixtures/example_dot_with_multi_link/shell/bashrc
@@ -1,0 +1,1 @@
+#bashrc test

--- a/fixtures/example_dot_with_multi_link/shell/zshrc
+++ b/fixtures/example_dot_with_multi_link/shell/zshrc
@@ -1,0 +1,1 @@
+#zshrc test

--- a/fixtures/example_dot_with_unlinked_file/Dot.toml
+++ b/fixtures/example_dot_with_unlinked_file/Dot.toml
@@ -3,4 +3,4 @@ name = "example_dot"
 authors = [ "Michael Mullins" ]
 
 [link]
-"shell/zshrc" = "~/.zshrc"
+"~/.zshrc" = "shell/zshrc"

--- a/packages/test_utils/src/fixtures.rs
+++ b/packages/test_utils/src/fixtures.rs
@@ -6,6 +6,7 @@ pub enum Fixture {
     ExampleDot,
     ExampleDotWithUnlinkedFile,
     ExampleDotWithLinkAdded,
+    ExampleDotWithMultiLink,
     ExampleDotWithDirectory,
     ConflictingDot,
 }
@@ -21,6 +22,7 @@ impl Fixture {
         match self {
             Self::ExampleDotWithDirectory => "example_dot_with_directory",
             Self::ExampleDotWithLinkAdded => "example_dot",
+            Self::ExampleDotWithMultiLink => "example_dot",
             Self::ExampleDotWithUnlinkedFile => "example_dot",
             Self::ExampleDot => "example_dot",
             Self::ConflictingDot => "conflicting_dot",
@@ -32,6 +34,9 @@ impl Fixture {
         match self {
             Self::ExampleDotWithLinkAdded => {
                 Self::templates_root().join("example_dot_with_link_added")
+            }
+            Self::ExampleDotWithMultiLink => {
+                Self::templates_root().join("example_dot_with_multi_link")
             }
             Self::ExampleDotWithUnlinkedFile => {
                 Self::templates_root().join("example_dot_with_unlinked_file")

--- a/src/dots.rs
+++ b/src/dots.rs
@@ -24,7 +24,7 @@ impl Dot {
         let links = config
             .link
             .iter()
-            .map(|(src, dest)| resolve(path, Link::new(src, dest)))
+            .map(|(dest, src)| resolve(path, Link::new(src, dest)))
             .collect();
 
         Ok(Dot {

--- a/src/plan/resolve.rs
+++ b/src/plan/resolve.rs
@@ -200,7 +200,7 @@ impl Display for ResolvedLink {
             None => dest_path,
         };
 
-        write!(f, "{} {} => {}", statusmark, src_msg, dest_msg)
+        write!(f, "{} {} => {}", statusmark, dest_msg, src_msg)
     }
 }
 

--- a/tests/output/install_fail_with_conflicts.err
+++ b/tests/output/install_fail_with_conflicts.err
@@ -1,10 +1,10 @@
 
 [conflicting_dot]
-✔ shell/bashrc => ~/.bashrc
+✔ ~/.bashrc => shell/bashrc
 
 [example_dot]
-✖ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✖ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [error] Multiple dots link to the following destination: ~/.bashrc
 

--- a/tests/output/install_fail_with_existing_directory_warning.err
+++ b/tests/output/install_fail_with_existing_directory_warning.err
@@ -1,7 +1,7 @@
 
 [example_dot]
-✔ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [warn] Destination already exists as a directory: ~/.bashrc
 

--- a/tests/output/install_fail_with_existing_file_warning.err
+++ b/tests/output/install_fail_with_existing_file_warning.err
@@ -1,7 +1,7 @@
 
 [example_dot]
-✔ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [warn] Destination already exists as a file: ~/.bashrc
 

--- a/tests/output/install_fail_with_existing_link_warning.err
+++ b/tests/output/install_fail_with_existing_link_warning.err
@@ -1,7 +1,7 @@
 
 [example_dot]
-✔ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [warn] Destination already exists as a symbolic link to another file: ~/.bashrc
 

--- a/tests/output/install_fail_with_missing_dotfile.err
+++ b/tests/output/install_fail_with_missing_dotfile.err
@@ -1,7 +1,7 @@
 
 [example_dot]
-✖ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✖ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [error] Can't find Source: shell/bashrc
 

--- a/tests/output/install_success.err
+++ b/tests/output/install_success.err
@@ -1,7 +1,7 @@
 
 [example_dot]
-✔ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [info] Looks Good! Nothing wrong with the current install plan!
 [info] Install was a success!

--- a/tests/output/install_success_when_linking_directory.err
+++ b/tests/output/install_success_when_linking_directory.err
@@ -1,6 +1,6 @@
 
 [example_dot_with_directory]
-✔ bin/ => ~/bin
+✔ ~/bin => bin/
 
 [info] Looks Good! Nothing wrong with the current install plan!
 [info] Install was a success!

--- a/tests/output/install_success_with_dry.err
+++ b/tests/output/install_success_with_dry.err
@@ -1,6 +1,6 @@
 
 [example_dot]
-✔ shell/bashrc => ~/.bashrc
-✔ shell/zshrc => ~/.zshrc
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
 
 [info] Looks Good! Nothing wrong with the current install plan!

--- a/tests/output/install_success_with_multiple_links_for_one_src.err
+++ b/tests/output/install_success_with_multiple_links_for_one_src.err
@@ -1,0 +1,12 @@
+[info] Adding {SRC_PATH}
+[info] Cloning...
+[info] Copying to {DEST_PATH}
+[info] Done!
+
+[example_dot]
+✔ ~/.bash_profile => shell/bashrc
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
+
+[info] Looks Good! Nothing wrong with the current install plan!
+[info] Install was a success!


### PR DESCRIPTION
fixes #45

This PR makes the following changes:

- It reverses the direction that you define symlinks in the `Dot.toml`
- It reverses the direction that those links are printed in the install out put to match.
- It enables users to create multiple links to the same source file.

[Example Dot.toml Diff](https://github.com/webdesserts/dots-cli/pull/49/files#diff-22faf5f5e9846bcad1053c53f64d5d4a3af582fd29596d86557a49d38e584e0b)
[Example Output Diff](https://github.com/webdesserts/dots-cli/pull/49/files#diff-cf03350fccf1c29c9d85064930babf98b5e7e7ef006ce8e21fec8a954e23b1dd)