### PR TITLE
`dots uninstall`

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -57,6 +57,22 @@ pub fn install(repo: &Option<String>, overwrite: bool, force: bool, dry: bool) {
     }
 }
 
+pub fn uninstall(name: &Option<String>) {
+    let env = Environment::new();
+    if let Some(name) = name {
+        dots::remove(name, &env).unwrap();
+    };
+    let plan = Plan::new(false);
+    let mut fs_manager = FSManager::init(&env);
+    let dots = dots::find_all(&env);
+    plan.clean(&env, &mut fs_manager, &dots)
+        .unwrap_or_else(|err| {
+            error!("failed to clean current install:");
+            error!("{}", err);
+            process::exit(1);
+        });
+}
+
 pub fn list(origins: bool) {
     let env = Environment::new();
     let mut lines = vec![];

--- a/src/dots.rs
+++ b/src/dots.rs
@@ -147,6 +147,32 @@ pub fn add(url: &str, overwrite: bool, env: &Environment) {
     };
 }
 
+pub fn remove(dot_name: &str, env: &Environment) -> Result<()> {
+    match find(dot_name, env) {
+        Some(dot) => {
+            fs::remove_dir_all(&dot.path).unwrap_or_else(|err| {
+                error!("Unable to remove dot directory:\n{}", dot.path);
+                error!("{}", err);
+                process::exit(1);
+            });
+        }
+        None => {
+            error!(
+                "Unable to find an installed dot with the name: {}",
+                dot_name
+            );
+            process::exit(1);
+        }
+    }
+    Ok(())
+}
+
+pub fn find(dot_name: &str, env: &Environment) -> Option<Dot> {
+    find_all(env)
+        .into_iter()
+        .find(|dot| dot.package.name == dot_name)
+}
+
 pub fn find_all(env: &Environment) -> Vec<Dot> {
     let dir = match env.root.read_dir() {
         Ok(read_dir) => read_dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ enum Commands {
         overwrite: bool,
     },
 
-    /// Installs all Dots
+    /// Downloads and links dots
     Install {
         /// An optional git url that points to a Dot repo that you want to add before installing
         repo: Option<String>,
@@ -72,6 +72,12 @@ enum Commands {
         /// Run through the install plan without actually making any changes
         #[clap(long)]
         dry: bool,
+    },
+
+    /// Removes and unlinks dots
+    Uninstall {
+        /// The name of the dot you'd like to remove
+        dot_name: Option<String>,
     },
 
     /// List the names of all installed dots
@@ -134,6 +140,7 @@ fn main() {
             force,
             dry,
         }) => commands::install(repo, *overwrite, *force, *dry),
+        Some(Commands::Uninstall { dot_name }) => commands::uninstall(dot_name),
         Some(Commands::List { origins }) => commands::list(*origins),
         Some(Commands::Path { dot }) => commands::path(dot),
         _ => {

--- a/tests/output/help.out
+++ b/tests/output/help.out
@@ -10,8 +10,9 @@ OPTIONS:
     -V, --version    Print version information
 
 SUBCOMMANDS:
-    add        Downloads the given git repo as a dot
-    help       Print this message or the help of the given subcommand(s)
-    install    Installs all Dots
-    list       List the names of all installed dots
-    path       Returns the installed location of a given dot
+    add          Downloads the given git repo as a dot
+    help         Print this message or the help of the given subcommand(s)
+    install      Downloads and links dots
+    list         List the names of all installed dots
+    path         Returns the installed location of a given dot
+    uninstall    Removes and unlinks dots

--- a/tests/output/install_help.out
+++ b/tests/output/install_help.out
@@ -1,5 +1,5 @@
 dots-install 
-Installs all Dots
+Downloads and links dots
 
 USAGE:
     dots install [OPTIONS] [REPO]

--- a/tests/output/uninstall_fail_with_unkown_dot.err
+++ b/tests/output/uninstall_fail_with_unkown_dot.err
@@ -1,0 +1,1 @@
+[error] Unable to find an installed dot with the name: {DOT_NAME}

--- a/tests/output/uninstall_help.out
+++ b/tests/output/uninstall_help.out
@@ -1,0 +1,11 @@
+dots-uninstall 
+Removes and unlinks dots
+
+USAGE:
+    dots uninstall [DOT_NAME]
+
+ARGS:
+    <DOT_NAME>    The name of the dot you'd like to remove
+
+OPTIONS:
+    -h, --help    Print help information

--- a/tests/subcommand_uninstall.rs
+++ b/tests/subcommand_uninstall.rs
@@ -1,0 +1,104 @@
+mod subcommand_uninstall {
+    use test_utils::{cargo_bin, AssertableOutput, Fixture, TestManager, TestResult};
+    const BIN: &str = cargo_bin!("dots");
+
+    #[test]
+    fn should_print_help_text_when_the_help_flag_is_passed() -> TestResult {
+        let manager = TestManager::new()?;
+        let output = manager.cmd(BIN)?.arg("uninstall").arg("--help").output()?;
+
+        output
+            .assert_stderr_eq("")
+            .assert_stdout_eq(include_str!("output/uninstall_help.out"))
+            .assert_success();
+
+        Ok(())
+    }
+
+    #[test]
+    fn should_remove_the_given_dot_when_its_name_is_passed_as_an_arg() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture1 = Fixture::ExampleDot;
+        let fixture2 = Fixture::ExampleDotWithDirectory;
+        let fixture1_path = manager.setup_fixture_as_git_repo(&fixture1)?;
+        let fixture2_path = manager.setup_fixture_as_git_repo(&fixture2)?;
+
+        let dot1_path = manager.expected_dot_path(&fixture1);
+        let dot2_path = manager.expected_dot_path(&fixture2);
+
+        manager
+            .cmd(BIN)?
+            .arg("install")
+            .arg(fixture1_path)
+            .output()?;
+
+        manager
+            .cmd(BIN)?
+            .arg("install")
+            .arg(fixture2_path)
+            .output()?;
+
+        manager
+            .cmd(BIN)?
+            .arg("uninstall")
+            .arg(fixture1.name())
+            .output()?
+            .assert_success();
+
+        assert!(!dot1_path.exists());
+        assert!(dot2_path.exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn should_remove_links_from_the_given_dot() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture1 = Fixture::ExampleDot;
+        let fixture2 = Fixture::ExampleDotWithDirectory;
+        let fixture1_path = manager.setup_fixture_as_git_repo(&fixture1)?;
+        let fixture2_path = manager.setup_fixture_as_git_repo(&fixture2)?;
+        let home_path = manager.home_dir();
+
+        manager
+            .cmd(BIN)?
+            .arg("install")
+            .arg(&fixture1_path)
+            .output()?;
+
+        manager
+            .cmd(BIN)?
+            .arg("install")
+            .arg(fixture2_path)
+            .output()?;
+
+        manager
+            .cmd(BIN)?
+            .arg("uninstall")
+            .arg(fixture1_path)
+            .output()?;
+
+        assert!(!home_path.join("./bashrc").exists());
+        assert!(!home_path.join("./zshrc").exists());
+
+        assert!(home_path.join("./bin").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn should_throw_and_error_if_there_is_no_dot_with_the_given_name() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture1 = Fixture::ExampleDot;
+        let dot_name = fixture1.name();
+
+        let output = manager.cmd(BIN)?.arg("uninstall").arg(dot_name).output()?;
+
+        output.assert_fail().assert_stderr_eq(format!(
+            include_str!("output/uninstall_fail_with_unkown_dot.err"),
+            DOT_NAME = dot_name
+        ));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR introduces a new `dots uninstall` command that will remove a dot with the given name from the dots directory and unlink all links associated with that dot. This change relies on the "clean" step that was recently introduced to the `dots install` command (see #48). Under the hood, uninstall essentially removes the directory of the dot and runs the clean step to clean up the remaining links. 