### PR TITLE
Add debug flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ mod styles {
 struct Cli {
     #[clap(subcommand)]
     commands: Option<Commands>,
-    /// prints extra logs for debugging purposes
+    /// Print extra logs for debugging purposes
     #[clap(long)]
     debug: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ mod styles {
 struct Cli {
     #[clap(subcommand)]
     commands: Option<Commands>,
+    /// prints extra logs for debugging purposes
+    #[clap(long)]
+    debug: bool,
 }
 
 #[derive(Subcommand)]
@@ -128,12 +131,15 @@ fn main() {
         writeln!(buf, "{}", indented)
     };
 
-    builder
-        .format(log_format)
-        .filter(None, log::LevelFilter::Info)
-        .init();
-
     let cli = Cli::parse();
+
+    let log_level = if cli.debug {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+
+    builder.format(log_format).filter(None, log_level).init();
 
     match &cli.commands {
         Some(Commands::Add { repo, overwrite }) => commands::add(repo, *overwrite),

--- a/tests/output/help.out
+++ b/tests/output/help.out
@@ -3,9 +3,10 @@ Michael Mullins <michael@webdesserts.com>
 A cli for managing all your dot(file)s
 
 USAGE:
-    dots [SUBCOMMAND]
+    dots [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+        --debug      Print extra logs for debugging purposes
     -h, --help       Print help information
     -V, --version    Print version information
 


### PR DESCRIPTION
This change now adds a `--debug` flag that will allow you to easily see debug logs. This should hopefully make it more accessible to both debug issues in development, as well as in production.