### PR TITLE
Release v0.5.3

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(cat:*)",
       "Bash(cargo check:*)",
       "Bash(cargo clippy:*)",
-      "WebSearch"
+      "WebSearch",
+      "Read(//tmp/**)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -7,7 +7,9 @@
       "Bash(cargo check:*)",
       "Bash(cargo clippy:*)",
       "WebSearch",
-      "Read(//tmp/**)"
+      "Read(//tmp/**)",
+      "Bash(cargo build:*)",
+      "Bash(git add:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "WebSearch",
       "Read(//tmp/**)",
       "Bash(cargo build:*)",
-      "Bash(git add:*)"
+      "Bash(git add:*)",
+      "Bash(cargo fmt:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,13 @@
 {
   "permissions": {
-    "allow": ["Bash(gh issue view:*)", "Bash(cargo test:*)", "Bash(cat:*)"],
+    "allow": [
+      "Bash(gh issue view:*)",
+      "Bash(cargo test:*)",
+      "Bash(cat:*)",
+      "Bash(cargo check:*)",
+      "Bash(cargo clippy:*)",
+      "WebSearch"
+    ],
     "deny": [],
     "ask": []
   }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": ["Bash(gh issue view:*)", "Bash(cargo test:*)", "Bash(cat:*)"],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,7 +3,7 @@ name: Rust
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to dots-cli will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to dots-cli will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.5.3] - 2025-01-10
+
+### Added
+- Debug flag support for verbose logging (#57)
+- Permission error testing utilities in TestManager
+- `make_readonly()` method for testing file permission scenarios
+- Display implementation for Link with pretty path formatting
+
+### Changed
+- **BREAKING INTERNAL**: Refactored reconciliation logic - cleanup now runs after installation instead of before
+- Moved footprint cleanup to execute after symlink creation for better error recovery
+- Improved error messages to show specific footprint file path on permission errors
+- Error output now displays context and root cause on separate lines for clarity
+- Validation now only prints newlines between dots, not before the first dot
+
+### Fixed
+- Fix #9: Now properly tracks and removes extra directories created during installation
+- Fix #26: Improved directory tracking and cleanup logic
+- Fixed footprint directory tracking to handle nested directory structures
+- Fixed issue where directories with user-created files were incorrectly removed
+- Added warnings when directories can't be removed due to user files
+
+### Internal
+- Implemented Actions system for filesystem operations, enabling better error collection and dry-run support
+- Added comprehensive snapshot tests for permission errors
+- Refactored Plan module to use three-phase approach: clean → validate → execute
+- Improved test infrastructure with reusable permission testing utilities
+- Ignore dotfiles in dots directory to prevent unintended tracking
+
+## [0.5.2] - 2024-XX-XX
+<!-- Previous release, details to be filled in -->
+
+## [0.5.1] - 2024-XX-XX
+<!-- Previous release, details to be filled in -->
+
+## [0.5.0] - 2024-XX-XX
+<!-- Previous release, details to be filled in -->
+
+[Unreleased]: https://github.com/webdesserts/dots-cli/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/webdesserts/dots-cli/compare/v0.5.2...v0.5.3
+[0.5.2]: https://github.com/webdesserts/dots-cli/compare/v0.5.1...v0.5.2
+[0.5.1]: https://github.com/webdesserts/dots-cli/compare/v0.5.0...v0.5.1
+[0.5.0]: https://github.com/webdesserts/dots-cli/releases/tag/v0.5.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# dots-cli Development Guidelines
+
+This document provides guidance for Claude Code when working on the dots-cli project.
+
+## Testing Approach
+
+### Philosophy
+- **Integration over Unit Tests**: Focus on CLI behavior, not internal implementation details
+- **Snapshot Testing**: Use comprehensive snapshot tests in `tests/output/` to capture complete CLI output
+- **Resilience**: Tests should survive refactoring by testing user-visible behavior
+
+### Structure
+- **Test Files**: Organized by subcommand in `tests/` (e.g., `subcommand_install.rs`)
+- **Fixtures**: Reusable test scenarios in `fixtures/` directory, managed via `packages/test_utils/src/fixtures.rs`
+- **Snapshots**: Expected output stored in `tests/output/` as `.err` (stderr) or `.out` (stdout) files
+
+### Naming Conventions
+- **Tests**: `it_should_[action]_[condition]` (e.g., `it_should_display_and_install_the_given_plan`)
+- **Fixtures**: `Example[Purpose][Variant]` (e.g., `ExampleDotWithSelfLink`)
+- **Snapshots**: `[command]_[outcome]_[condition].[err|out]` (e.g., `install_success_when_self_linking.err`)
+
+### Key Principles
+- Test complete user scenarios rather than specific bugs or formatting details
+- Verify both CLI output (via snapshots) and actual behavior (e.g., symlinks created)
+- Use existing test infrastructure (`TestManager`, fixtures) rather than creating new patterns
+- For bug fixes, create comprehensive tests covering the entire user workflow
+
+## Implementation Guidelines
+- Follow existing code conventions and patterns
+- Use existing libraries and utilities rather than introducing new dependencies
+- Maintain consistency with the project's established architecture
+- Run linting and type checking when available

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,201 @@
+# Contributing to dots-cli
+
+Thank you for your interest in contributing to dots-cli! This document provides guidelines and instructions for contributing.
+
+## Development Setup
+
+### Prerequisites
+- Rust stable toolchain
+- Git
+
+### Getting Started
+```bash
+# Clone the repository
+git clone https://github.com/webdesserts/dots-cli
+cd dots-cli
+
+# Run tests
+cargo test --all
+
+# Run the CLI locally
+cargo run -- <command>
+```
+
+## Testing
+
+### Philosophy
+dots-cli follows an integration testing approach:
+- **Focus on CLI behavior**, not internal implementation details
+- **Snapshot testing** for comprehensive output validation
+- **Tests should survive refactoring** by testing user-visible behavior
+
+### Running Tests
+```bash
+# Run all tests
+cargo test --all
+
+# Run specific test file
+cargo test --test subcommand_install
+
+# Run specific test
+cargo test it_should_display_and_install_the_given_plan
+```
+
+### Writing Tests
+Tests are organized in `tests/` by subcommand:
+- `tests/subcommand_install.rs`
+- `tests/subcommand_add.rs`
+- etc.
+
+Expected output is stored in `tests/output/` as snapshot files.
+
+**Test Naming Convention:**
+```rust
+#[test]
+fn it_should_[action]_[condition]() -> TestResult {
+    // Test implementation
+}
+```
+
+**Example:**
+```rust
+#[test]
+fn it_should_fail_when_footprint_is_readonly() -> TestResult {
+    let manager = TestManager::new()?;
+    let fixture_path = manager.setup_fixture_as_git_repo(&Fixture::ExampleDot)?;
+
+    manager.cmd(BIN)?.arg("add").arg(&fixture_path).output()?;
+    manager.cmd(BIN)?.arg("install").output()?;
+
+    // Make footprint readonly to simulate permission error
+    manager.make_readonly(manager.footprint_path())?;
+
+    let output = manager.cmd(BIN)?.arg("install").output()?;
+    let expected_err = include_str!("output/install_fail_with_readonly_footprint.err");
+
+    output
+        .assert_stderr_eq(expected_err)
+        .assert_fail();
+
+    Ok(())
+}
+```
+
+See `CLAUDE.md` for more detailed testing guidelines.
+
+## Code Quality
+
+### Before Committing
+Run these checks locally:
+```bash
+# Run tests
+cargo test --all
+
+# Check for clippy warnings
+cargo clippy --all-targets -- -D warnings
+
+# Format code
+cargo fmt --all
+```
+
+### CI
+GitHub Actions runs tests on:
+- Ubuntu latest (stable Rust)
+- macOS latest (stable Rust)
+
+Checks formatting and clippy on nightly.
+
+## Release Process
+
+### Prerequisites
+- `cargo-release` installed: `cargo install cargo-release`
+- Write access to the repository
+- Clean working directory
+
+### Release Steps
+
+**1. Pre-release checks** (fix any issues before versioning)
+```bash
+cargo test --all
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Commit any fixes if needed.
+
+**2. Update CHANGELOG.md**
+- Move unreleased changes to new version section
+- Add release date
+- Update comparison links at bottom
+- Commit the changelog:
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG for v0.X.X"
+```
+
+**3. Run release**
+```bash
+# For patch release (0.5.2 -> 0.5.3)
+cargo release patch --execute
+
+# For minor release (0.5.3 -> 0.6.0)
+cargo release minor --execute
+
+# For major release (0.6.0 -> 1.0.0)
+cargo release major --execute
+```
+
+This will:
+- Update version in `Cargo.toml`
+- Create a version bump commit
+- Create a git tag (e.g., `v0.5.3`)
+- Push commits and tags to GitHub
+- Publish to crates.io (if configured)
+
+**4. Merge to master** (optional, for syncing main branch)
+```bash
+git checkout master
+git merge v0.5.x
+git push origin master
+```
+
+### Version Numbering
+We follow [Semantic Versioning](https://semver.org/):
+- **Patch** (0.5.2 -> 0.5.3): Bug fixes, non-breaking changes
+- **Minor** (0.5.3 -> 0.6.0): New features, non-breaking changes
+- **Major** (0.6.0 -> 1.0.0): Breaking changes
+
+### Manual Release (if needed)
+If `cargo-release` isn't available:
+
+```bash
+# 1. Update version in Cargo.toml manually
+# 2. Commit version bump
+git add Cargo.toml
+git commit -m "chore: bump version to 0.5.3"
+
+# 3. Create and push tag
+git tag v0.5.3
+git push origin v0.5.x --tags
+
+# 4. Publish to crates.io
+cargo publish
+```
+
+## Branch Strategy
+
+- **master**: Stable releases
+- **v0.5.x**: Current development branch for 0.5.x releases
+- **feature branches**: For new features, merged into v0.5.x
+
+## Code Style
+
+- Follow Rust conventions
+- Use `rustfmt` for formatting
+- Address `clippy` warnings
+- Add documentation comments for public APIs
+- Keep functions focused and testable
+
+## Questions?
+
+Feel free to open an issue for any questions about contributing!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,11 +152,18 @@ This will:
 - Push commits and tags to GitHub
 - Publish to crates.io (if configured)
 
-**4. Merge to master** (optional, for syncing main branch)
+**4. Create Pull Request**
+- Push your feature branch to GitHub
+- Create a PR from your branch to `main`
+- Wait for CI checks to pass
+- Merge the PR on GitHub
+
+**5. Release from main**
+After the PR is merged:
 ```bash
-git checkout master
-git merge v0.5.x
-git push origin master
+git checkout main
+git pull origin main
+cargo release patch --execute
 ```
 
 ### Version Numbering
@@ -186,9 +193,9 @@ cargo publish
 
 ## Branch Strategy
 
-- **master**: Stable releases
+- **main**: Stable releases (publish from this branch)
 - **v0.5.x**: Current development branch for 0.5.x releases
-- **feature branches**: For new features, merged into v0.5.x
+- **feature branches**: For new features, merged into version branches via PR to main
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,10 +160,12 @@ git push origin master
 ```
 
 ### Version Numbering
-We follow [Semantic Versioning](https://semver.org/):
-- **Patch** (0.5.2 -> 0.5.3): Bug fixes, non-breaking changes
-- **Minor** (0.5.3 -> 0.6.0): New features, non-breaking changes
-- **Major** (0.6.0 -> 1.0.0): Breaking changes
+Version numbers follow the pattern `major.minor.patch`:
+- **Patch** (0.5.2 -> 0.5.3): Bug fixes and minor changes
+- **Minor** (0.5.3 -> 0.6.0): New features and improvements
+- **Major** (0.6.0 -> 1.0.0): Major changes
+
+Note: This project does not strictly adhere to semantic versioning.
 
 ### Manual Release (if needed)
 If `cargo-release` isn't available:

--- a/fixtures/example_dot_with_nested_directories/Dot.toml
+++ b/fixtures/example_dot_with_nested_directories/Dot.toml
@@ -1,0 +1,7 @@
+[package]
+name = "example_dot"
+authors = [ "Michael Mullins" ]
+
+[link]
+"~/.bashrc" = "shell/bashrc"
+"~/.config/zsh/.zshrc" = "shell/zshrc"

--- a/fixtures/example_dot_with_nested_directories/shell/bashrc
+++ b/fixtures/example_dot_with_nested_directories/shell/bashrc
@@ -1,0 +1,1 @@
+#bashrc test

--- a/fixtures/example_dot_with_nested_directories/shell/zshrc
+++ b/fixtures/example_dot_with_nested_directories/shell/zshrc
@@ -1,0 +1,1 @@
+#zshrc test

--- a/fixtures/example_dot_with_self_link/Dot.toml
+++ b/fixtures/example_dot_with_self_link/Dot.toml
@@ -1,0 +1,6 @@
+[package]
+name = "example_dot_with_self_link"
+authors = ["Test Author"]
+
+[link]
+"~/test_self_link" = "./"

--- a/fixtures/example_dot_with_self_link/test_file.txt
+++ b/fixtures/example_dot_with_self_link/test_file.txt
@@ -1,0 +1,1 @@
+This is a test file in the self-linking dot directory.

--- a/packages/test_utils/src/fixtures.rs
+++ b/packages/test_utils/src/fixtures.rs
@@ -9,6 +9,7 @@ pub enum Fixture {
     ExampleDotWithMultiLink,
     ExampleDotWithDirectory,
     ConflictingDot,
+    ExampleDotWithSelfLink,
 }
 
 impl Fixture {
@@ -26,6 +27,7 @@ impl Fixture {
             Self::ExampleDotWithUnlinkedFile => "example_dot",
             Self::ExampleDot => "example_dot",
             Self::ConflictingDot => "conflicting_dot",
+            Self::ExampleDotWithSelfLink => "example_dot_with_self_link",
         }
     }
 

--- a/packages/test_utils/src/fixtures.rs
+++ b/packages/test_utils/src/fixtures.rs
@@ -8,6 +8,7 @@ pub enum Fixture {
     ExampleDotWithLinkAdded,
     ExampleDotWithMultiLink,
     ExampleDotWithDirectory,
+    ExampleDotWithNestedDirectories,
     ConflictingDot,
     ExampleDotWithSelfLink,
 }
@@ -22,6 +23,7 @@ impl Fixture {
     pub fn name(&self) -> &str {
         match self {
             Self::ExampleDotWithDirectory => "example_dot_with_directory",
+            Self::ExampleDotWithNestedDirectories => "example_dot",
             Self::ExampleDotWithLinkAdded => "example_dot",
             Self::ExampleDotWithMultiLink => "example_dot",
             Self::ExampleDotWithUnlinkedFile => "example_dot",
@@ -33,18 +35,14 @@ impl Fixture {
 
     /** The path where this specific fixture's template can be found */
     pub fn template_path(&self) -> Utf8PathBuf {
-        match self {
-            Self::ExampleDotWithLinkAdded => {
-                Self::templates_root().join("example_dot_with_link_added")
-            }
-            Self::ExampleDotWithMultiLink => {
-                Self::templates_root().join("example_dot_with_multi_link")
-            }
-            Self::ExampleDotWithUnlinkedFile => {
-                Self::templates_root().join("example_dot_with_unlinked_file")
-            }
-            _ => Self::templates_root().join(self.name()),
-        }
+        let subpath = match self {
+            Self::ExampleDotWithLinkAdded => "example_dot_with_link_added",
+            Self::ExampleDotWithMultiLink => "example_dot_with_multi_link",
+            Self::ExampleDotWithUnlinkedFile => "example_dot_with_unlinked_file",
+            Self::ExampleDotWithNestedDirectories => "example_dot_with_nested_directories",
+            _ => self.name(),
+        };
+        Self::templates_root().join(subpath)
     }
 }
 

--- a/packages/test_utils/src/test_manager.rs
+++ b/packages/test_utils/src/test_manager.rs
@@ -1,6 +1,7 @@
 use crate::Fixture;
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
+use std::cell::RefCell;
 use std::fs;
 use std::io::Read;
 use std::process::Command;
@@ -12,12 +13,19 @@ use utils::git;
 
 pub struct TestManager {
     tmpdir: TempDir,
+    /// Tracks files we've made readonly for testing permission errors.
+    /// Stores (path, original_readonly_state) so we can restore permissions
+    /// before the temp directory cleanup attempts to delete files.
+    readonly_files: RefCell<Vec<(Utf8PathBuf, bool)>>,
 }
 
 impl TestManager {
     pub fn new() -> Result<Self> {
         let tmpdir = tempdir()?;
-        let test_manager = TestManager { tmpdir };
+        let test_manager = TestManager {
+            tmpdir,
+            readonly_files: RefCell::new(Vec::new()),
+        };
         Ok(test_manager)
     }
 
@@ -108,6 +116,60 @@ impl TestManager {
         let contents = contents.as_ref();
         fs::write(self.footprint_path(), contents)?;
         Ok(())
+    }
+
+    /// Makes a file readonly for testing permission errors.
+    ///
+    /// The file's original permissions will be automatically restored when the
+    /// TestManager is dropped (at the end of the test). This ensures temp directory
+    /// cleanup doesn't fail due to readonly files.
+    ///
+    /// ## Example
+    /// ```rust
+    /// #[test]
+    /// fn test_permission_error() -> TestResult {
+    ///     let manager = TestManager::new()?;
+    ///     // ... setup code ...
+    ///
+    ///     // Make footprint readonly to test permission denied error handling
+    ///     manager.make_readonly(manager.footprint_path())?;
+    ///
+    ///     // ... test code ...
+    ///
+    /// } // Permissions automatically restored here when manager drops
+    /// ```
+    pub fn make_readonly(&self, path: impl AsRef<Utf8Path>) -> Result<()> {
+        let path = path.as_ref();
+        let perms = fs::metadata(path)?.permissions();
+
+        // Store original state for restoration on drop
+        self.readonly_files
+            .borrow_mut()
+            .push((path.to_owned(), perms.readonly()));
+
+        // Make the file readonly
+        let mut new_perms = perms;
+        new_perms.set_readonly(true);
+        fs::set_permissions(path, new_perms)?;
+
+        Ok(())
+    }
+}
+
+impl Drop for TestManager {
+    fn drop(&mut self) {
+        // Restore all readonly permissions before temp directory cleanup.
+        // This prevents the temp directory cleanup from failing when trying
+        // to delete readonly files.
+        for (path, original_readonly) in self.readonly_files.borrow().iter() {
+            let _ = (|| -> Result<()> {
+                let mut perms = fs::metadata(path)?.permissions();
+                perms.set_readonly(*original_readonly);
+                fs::set_permissions(path, perms)?;
+                Ok(())
+            })();
+        }
+        // tmpdir drops after this and cleans up the temp directory
     }
 }
 

--- a/packages/utils/src/fs.rs
+++ b/packages/utils/src/fs.rs
@@ -88,3 +88,14 @@ where
     path.canonicalize()
         .map(|path| Utf8PathBuf::from_path_buf(path).unwrap())
 }
+
+/// Convert absolute paths to use ~ for home directory (opposite of canonicalize)
+pub fn pretty_path<P>(path: P) -> String
+where
+    P: AsRef<Utf8Path>,
+{
+    let path = path.as_ref();
+    path.strip_prefix(home())
+        .map(|rel_path| format!("~/{}", rel_path))
+        .unwrap_or_else(|_| path.to_string())
+}

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -22,24 +22,18 @@ pub fn install(repo: &Option<String>, overwrite: bool, force: bool, dry: bool) {
     let env = Environment::new();
     if let Some(url) = repo {
         dots::add(url, overwrite, &env);
+        eprintln!();
     };
     let dots = dots::find_all(&env);
 
     let mut plan = Plan::new(force);
 
     let mut fs_manager = FSManager::init(&env);
-    plan.clean(&env, &mut fs_manager, &dots)
-        .unwrap_or_else(|err| {
-            error!("failed to clean current install:");
-            error!("{}", err);
-            process::exit(1);
-        });
 
     /* Validate whether the plan passes or fails */
-    match plan.validate(dots) {
-        Ok(plan) => {
+    match plan.validate(&dots) {
+        Ok(_) => {
             info!("Looks Good! Nothing wrong with the current install plan!");
-            plan
         }
         Err(err) => {
             error!("{}", err);
@@ -50,20 +44,28 @@ pub fn install(repo: &Option<String>, overwrite: bool, force: bool, dry: bool) {
 
     if dry {
         process::exit(1)
-    } else {
-        match plan.execute(&mut fs_manager, force) {
-            Ok(_) => {
-                info!("Install was a success!");
-                process::exit(0)
-            }
-            Err(err) => {
-                error!("Install Failed!");
-                error!("{}", err);
+    }
 
-                process::exit(1)
-            }
+    match plan.execute(&env, &mut fs_manager, force) {
+        Ok(_) => {}
+        Err(err) => {
+            error!("Install Failed!");
+            error!("{}", err);
+
+            process::exit(1)
         }
     }
+
+    // Clean up stale symlinks and directories after installation
+    plan.clean(&env, &mut fs_manager, &dots, false)
+        .unwrap_or_else(|err| {
+            error!("failed to clean current install:");
+            error!("{}", err);
+            process::exit(1);
+        });
+
+    info!("Install was a success!");
+    process::exit(0)
 }
 
 pub fn uninstall(name: &Option<String>) {
@@ -74,7 +76,9 @@ pub fn uninstall(name: &Option<String>) {
     let plan = Plan::new(false);
     let mut fs_manager = FSManager::init(&env);
     let dots = dots::find_all(&env);
-    plan.clean(&env, &mut fs_manager, &dots)
+
+    // Clean up stale symlinks and directories, then reconcile footprint
+    plan.clean(&env, &mut fs_manager, &dots, false)
         .unwrap_or_else(|err| {
             error!("failed to clean current install:");
             error!("{}", err);

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -51,6 +51,9 @@ pub fn install(repo: &Option<String>, overwrite: bool, force: bool, dry: bool) {
         Err(err) => {
             error!("Install Failed!");
             error!("{}", err);
+            if let Some(cause) = err.source() {
+                error!("{}", cause);
+            }
 
             process::exit(1)
         }
@@ -61,6 +64,9 @@ pub fn install(repo: &Option<String>, overwrite: bool, force: bool, dry: bool) {
         .unwrap_or_else(|err| {
             error!("failed to clean current install:");
             error!("{}", err);
+            if let Some(cause) = err.source() {
+                error!("{}", cause);
+            }
             process::exit(1);
         });
 
@@ -82,6 +88,9 @@ pub fn uninstall(name: &Option<String>) {
         .unwrap_or_else(|err| {
             error!("failed to clean current install:");
             error!("{}", err);
+            if let Some(cause) = err.source() {
+                error!("{}", cause);
+            }
             process::exit(1);
         });
 }

--- a/src/dots.rs
+++ b/src/dots.rs
@@ -214,6 +214,13 @@ pub fn find_all(env: &Environment) -> Vec<Dot> {
             continue;
         }
 
+        // Skip hidden directories (starting with .)
+        if let Some(file_name) = utf8_path.file_name() {
+            if file_name.starts_with('.') {
+                continue;
+            }
+        }
+
         if let Ok(dot) = Dot::new(utf8_path) {
             dots.push(dot)
         }

--- a/src/footprint.rs
+++ b/src/footprint.rs
@@ -92,8 +92,8 @@ src = "/test/src2"
 dest = "/test/dest2"
 "#;
 
-        let footprint: Footprint = toml::from_str(old_format_toml)
-            .expect("Should parse old format without dirs field");
+        let footprint: Footprint =
+            toml::from_str(old_format_toml).expect("Should parse old format without dirs field");
 
         // dirs should default to empty set
         assert!(footprint.dirs.is_empty());
@@ -103,8 +103,12 @@ dest = "/test/dest2"
 
         // Verify links contain expected paths
         let links: Vec<_> = footprint.links.iter().collect();
-        assert!(links.iter().any(|link| link.src.path.as_str() == "/test/src1"));
-        assert!(links.iter().any(|link| link.dest.path.as_str() == "/test/dest1"));
+        assert!(links
+            .iter()
+            .any(|link| link.src.path.as_str() == "/test/src1"));
+        assert!(links
+            .iter()
+            .any(|link| link.dest.path.as_str() == "/test/dest1"));
     }
 
     #[test]
@@ -118,13 +122,17 @@ src = "/test/src1"
 dest = "/test/dest1"
 "#;
 
-        let footprint: Footprint = toml::from_str(new_format_toml)
-            .expect("Should parse new format with dirs field");
+        let footprint: Footprint =
+            toml::from_str(new_format_toml).expect("Should parse new format with dirs field");
 
         // dirs should contain expected directories
         assert_eq!(footprint.dirs.len(), 2);
-        assert!(footprint.dirs.contains(&Utf8PathBuf::from("/test/created_dir1")));
-        assert!(footprint.dirs.contains(&Utf8PathBuf::from("/test/created_dir2")));
+        assert!(footprint
+            .dirs
+            .contains(&Utf8PathBuf::from("/test/created_dir1")));
+        assert!(footprint
+            .dirs
+            .contains(&Utf8PathBuf::from("/test/created_dir2")));
 
         // links should parse correctly
         assert_eq!(footprint.links.len(), 1);
@@ -135,15 +143,14 @@ dest = "/test/dest1"
         // Test that footprint with empty dirs serializes correctly
         let footprint = Footprint::default();
 
-        let serialized = toml::to_string(&footprint)
-            .expect("Should serialize empty footprint");
+        let serialized = toml::to_string(&footprint).expect("Should serialize empty footprint");
 
         // Should include dirs = [] in output
         assert!(serialized.contains("dirs = []"));
 
         // Should be parseable back
-        let parsed: Footprint = toml::from_str(&serialized)
-            .expect("Should parse serialized footprint");
+        let parsed: Footprint =
+            toml::from_str(&serialized).expect("Should parse serialized footprint");
 
         assert!(parsed.dirs.is_empty());
         assert!(parsed.links.is_empty());
@@ -155,11 +162,10 @@ dest = "/test/dest1"
         let mut footprint = Footprint::default();
         footprint.dirs.insert(Utf8PathBuf::from("/test/dir"));
 
-        let serialized = toml::to_string(&footprint)
-            .expect("Should serialize footprint with dirs");
+        let serialized = toml::to_string(&footprint).expect("Should serialize footprint with dirs");
 
-        let parsed: Footprint = toml::from_str(&serialized)
-            .expect("Should parse back serialized footprint");
+        let parsed: Footprint =
+            toml::from_str(&serialized).expect("Should parse back serialized footprint");
 
         assert_eq!(footprint.dirs, parsed.dirs);
         assert_eq!(footprint.links, parsed.links);

--- a/src/footprint.rs
+++ b/src/footprint.rs
@@ -2,9 +2,13 @@ use std::collections::BTreeSet;
 
 use crate::plan::links::{Anchor, Link};
 use camino::Utf8PathBuf;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Default, Clone)]
 pub struct Footprint {
+    #[serde(default)]
+    pub dirs: BTreeSet<Utf8PathBuf>,
+    #[serde(default)]
     pub links: BTreeSet<Link>,
 }
 
@@ -68,5 +72,96 @@ impl serde::Serialize for Link {
     {
         let footprint_link: FootprintLink = self.into();
         footprint_link.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_backward_compatibility_old_format_without_dirs() {
+        // Test that old footprint format (without dirs field) parses correctly
+        let old_format_toml = r#"
+[[links]]
+src = "/test/src1"
+dest = "/test/dest1"
+
+[[links]]
+src = "/test/src2"
+dest = "/test/dest2"
+"#;
+
+        let footprint: Footprint = toml::from_str(old_format_toml)
+            .expect("Should parse old format without dirs field");
+
+        // dirs should default to empty set
+        assert!(footprint.dirs.is_empty());
+
+        // links should parse correctly
+        assert_eq!(footprint.links.len(), 2);
+
+        // Verify links contain expected paths
+        let links: Vec<_> = footprint.links.iter().collect();
+        assert!(links.iter().any(|link| link.src.path.as_str() == "/test/src1"));
+        assert!(links.iter().any(|link| link.dest.path.as_str() == "/test/dest1"));
+    }
+
+    #[test]
+    fn test_new_format_with_dirs() {
+        // Test that new footprint format (with dirs field) parses correctly
+        let new_format_toml = r#"
+dirs = ["/test/created_dir1", "/test/created_dir2"]
+
+[[links]]
+src = "/test/src1"
+dest = "/test/dest1"
+"#;
+
+        let footprint: Footprint = toml::from_str(new_format_toml)
+            .expect("Should parse new format with dirs field");
+
+        // dirs should contain expected directories
+        assert_eq!(footprint.dirs.len(), 2);
+        assert!(footprint.dirs.contains(&Utf8PathBuf::from("/test/created_dir1")));
+        assert!(footprint.dirs.contains(&Utf8PathBuf::from("/test/created_dir2")));
+
+        // links should parse correctly
+        assert_eq!(footprint.links.len(), 1);
+    }
+
+    #[test]
+    fn test_empty_dirs_serialization() {
+        // Test that footprint with empty dirs serializes correctly
+        let footprint = Footprint::default();
+
+        let serialized = toml::to_string(&footprint)
+            .expect("Should serialize empty footprint");
+
+        // Should include dirs = [] in output
+        assert!(serialized.contains("dirs = []"));
+
+        // Should be parseable back
+        let parsed: Footprint = toml::from_str(&serialized)
+            .expect("Should parse serialized footprint");
+
+        assert!(parsed.dirs.is_empty());
+        assert!(parsed.links.is_empty());
+    }
+
+    #[test]
+    fn test_roundtrip_with_dirs() {
+        // Test serialize -> deserialize roundtrip with dirs
+        let mut footprint = Footprint::default();
+        footprint.dirs.insert(Utf8PathBuf::from("/test/dir"));
+
+        let serialized = toml::to_string(&footprint)
+            .expect("Should serialize footprint with dirs");
+
+        let parsed: Footprint = toml::from_str(&serialized)
+            .expect("Should parse back serialized footprint");
+
+        assert_eq!(footprint.dirs, parsed.dirs);
+        assert_eq!(footprint.links, parsed.links);
     }
 }

--- a/src/fs_manager.rs
+++ b/src/fs_manager.rs
@@ -45,6 +45,37 @@ impl FSManager {
         Ok(())
     }
 
+    /** Removes a directory from the footprint tracking */
+    pub fn remove_footprint_dir(&mut self, dir_path: &Utf8PathBuf) -> Result<()> {
+        self.footprint.dirs.remove(dir_path);
+        self.save_footprint()?;
+        Ok(())
+    }
+
+    /** Creates a directory and tracks it if it didn't exist before */
+    pub fn create_directory(&mut self, dir_path: &Utf8PathBuf) -> Result<()> {
+        let existed = dir_path.exists();
+        fs::create_dir_all(dir_path)?;
+        // Only track directories that we actually created
+        if !existed {
+            self.footprint.dirs.insert(dir_path.clone());
+            self.save_footprint()?;
+        }
+        Ok(())
+    }
+
+    /** Removes a file from the filesystem */
+    pub fn remove_file(&self, file_path: &Utf8PathBuf) -> io::Result<()> {
+        fs::remove_file(file_path)?;
+        Ok(())
+    }
+
+    /** Removes a directory and all its contents from the filesystem */
+    pub fn remove_directory(&self, dir_path: &Utf8PathBuf) -> io::Result<()> {
+        fs::remove_dir_all(dir_path)?;
+        Ok(())
+    }
+
     /** Write the current footprint to the toml file */
     fn save_footprint(&self) -> Result<()> {
         let contents = toml::to_string(&self.footprint)?;

--- a/src/fs_manager.rs
+++ b/src/fs_manager.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use std::{fs, io, os::unix};
 
 use crate::{dots::Environment, footprint::Footprint, plan::links::Link};
@@ -21,62 +21,75 @@ impl FSManager {
     }
 
 
-    /** Removes a link from the footprint file */
-    pub fn remove_footprint_link(&mut self, link: &Link) -> Result<()> {
-        self.footprint.links.remove(link);
-        self.save_footprint()?;
+    // ============================================================================
+    // Filesystem Primitives (no footprint changes)
+    // ============================================================================
+
+    /// Creates a symlink on the filesystem
+    pub fn create_symlink(&self, link: &Link) -> io::Result<()> {
+        unix::fs::symlink(&link.src.path, &link.dest.path)?;
         Ok(())
     }
 
-    /**
-     * Removes the given symlink from fs
-     */
+    /// Removes a symlink from the filesystem
     pub fn remove_symlink(&self, link: &Link) -> io::Result<()> {
         fs::remove_file(&link.dest.path)?;
         Ok(())
     }
 
-    /** Creates the given symlink and tracks that link in the dot footprint */
-    pub fn create_symlink(&mut self, link: &Link) -> Result<()> {
-        unix::fs::symlink(&link.src.path, &link.dest.path)?;
-        self.footprint.links.insert(link.clone());
-        self.save_footprint()?;
-
-        Ok(())
-    }
-
-    /** Removes a directory from the footprint tracking */
-    pub fn remove_footprint_dir(&mut self, dir_path: &Utf8PathBuf) -> Result<()> {
-        self.footprint.dirs.remove(dir_path);
-        self.save_footprint()?;
-        Ok(())
-    }
-
-    /** Creates a directory and tracks it if it didn't exist before */
-    pub fn create_directory(&mut self, dir_path: &Utf8PathBuf) -> Result<()> {
+    /// Creates a directory on the filesystem, returns true if it was created
+    pub fn create_directory(&self, dir_path: &Utf8Path) -> io::Result<bool> {
         let existed = dir_path.exists();
         fs::create_dir_all(dir_path)?;
-        // Only track directories that we actually created
-        if !existed {
-            self.footprint.dirs.insert(dir_path.clone());
-            self.save_footprint()?;
-        }
-        Ok(())
+        Ok(!existed)
     }
 
-    /** Removes a file from the filesystem */
-    pub fn remove_file(&self, file_path: &Utf8PathBuf) -> io::Result<()> {
-        fs::remove_file(file_path)?;
-        Ok(())
-    }
-
-    /** Removes a directory and all its contents from the filesystem */
-    pub fn remove_directory(&self, dir_path: &Utf8PathBuf) -> io::Result<()> {
+    /// Removes a directory from the filesystem
+    pub fn remove_directory(&self, dir_path: &Utf8Path) -> io::Result<()> {
         fs::remove_dir_all(dir_path)?;
         Ok(())
     }
 
-    /** Write the current footprint to the toml file */
+    /// Removes a file from the filesystem
+    pub fn remove_file(&self, file_path: &Utf8Path) -> io::Result<()> {
+        fs::remove_file(file_path)?;
+        Ok(())
+    }
+
+    /// Reads directory entries
+    pub fn read_dir(&self, dir_path: &Utf8Path) -> io::Result<fs::ReadDir> {
+        fs::read_dir(dir_path)
+    }
+
+    // ============================================================================
+    // Footprint Primitives (no filesystem changes)
+    // ============================================================================
+
+    /// Adds a symlink to the footprint tracking
+    pub fn track_symlink(&mut self, link: &Link) -> Result<()> {
+        self.footprint.links.insert(link.clone());
+        self.save_footprint()?;
+        Ok(())
+    }
+
+    /// Adds a directory to the footprint tracking
+    pub fn track_directory(&mut self, dir_path: &Utf8Path) -> Result<()> {
+        self.footprint.dirs.insert(dir_path.to_path_buf());
+        self.save_footprint()?;
+        Ok(())
+    }
+
+    /// Edit the footprint with a closure, automatically saving changes when done
+    pub fn edit_footprint<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut Footprint),
+    {
+        f(&mut self.footprint);
+        self.save_footprint()?;
+        Ok(())
+    }
+
+    /// Write the current footprint to the toml file
     fn save_footprint(&self) -> Result<()> {
         let contents = toml::to_string(&self.footprint)?;
         fs::write(&self.footprint_path, contents)?;

--- a/src/fs_manager.rs
+++ b/src/fs_manager.rs
@@ -101,7 +101,7 @@ impl FSManager {
 
     fn read_and_parse_footprint(footprint_path: &Utf8PathBuf) -> Footprint {
         let Ok(string) = fs::read_to_string(footprint_path) else {
-            return Footprint::default()
+            return Footprint::default();
         };
         return toml::from_str(string.as_ref()).unwrap_or_else(|err| {
             warn!("Error parsing {footprint_path}:\n{err}");

--- a/src/fs_manager.rs
+++ b/src/fs_manager.rs
@@ -6,7 +6,7 @@ use crate::{dots::Environment, footprint::Footprint, plan::links::Link};
 
 pub struct FSManager {
     footprint_path: Utf8PathBuf,
-    footprint: Footprint,
+    pub footprint: Footprint,
 }
 
 impl FSManager {
@@ -20,48 +20,9 @@ impl FSManager {
         }
     }
 
-    /**
-     * This method does three things:
-     *
-     * 1. removes any footprint links that DO NOT have corresponding symlinks on the fs
-     * 2. removes any footprint links that DO have corresponding symlinks on the fs, but those symlinks
-     *    do no point to the correct source.
-     * 3. removes the symlink for footprint links that DO NOT have corresponding links in any Dot.toml
-     */
-    pub fn clean(&mut self, valid_links: &Vec<Link>, env: &Environment) -> Result<()> {
-        let original_footprint = self.footprint.clone();
-        debug!("VALID LINKS");
-        for link in valid_links {
-            debug!("  {link:?}")
-        }
-        debug!("FOOTPRINT LINKS");
-        for link in &original_footprint.links {
-            let symlink_exists = link.dest.path.is_symlink();
-            debug!("  {link:?}");
-            debug!("    link is on fs: {}", link.exists());
-            debug!("    link is in dots: {}", valid_links.contains(link));
-            if !symlink_exists {
-                debug!("    no symlink detected, removing footprint link");
-                self.remove_footprint_link(link)?;
-            } else if !link.exists() {
-                debug!("    symlink detected, but pointing to wrong dest, removing footprint link");
-                self.remove_footprint_link(link)?;
-            } else if !link.src.path.starts_with(env.root()) {
-                debug!("    symlink exists, but source is outside of dots dir, removing footprint link");
-                self.remove_footprint_link(link)?;
-            } else if !valid_links.contains(link) {
-                debug!("    link is on fs but is no longer present in dot files, removing symlink & footprint link");
-                self.remove_symlink(link)?;
-                self.remove_footprint_link(link)?;
-            } else {
-                debug!("    leaving link alone")
-            }
-        }
-        Ok(())
-    }
 
     /** Removes a link from the footprint file */
-    fn remove_footprint_link(&mut self, link: &Link) -> Result<()> {
+    pub fn remove_footprint_link(&mut self, link: &Link) -> Result<()> {
         self.footprint.links.remove(link);
         self.save_footprint()?;
         Ok(())

--- a/src/fs_manager.rs
+++ b/src/fs_manager.rs
@@ -20,6 +20,9 @@ impl FSManager {
         }
     }
 
+    pub fn footprint_path(&self) -> &Utf8Path {
+        &self.footprint_path
+    }
 
     // ============================================================================
     // Filesystem Primitives (no footprint changes)

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,9 @@ mod styles {
 struct Cli {
     #[clap(subcommand)]
     commands: Option<Commands>,
+    /// Print extra logs for debugging purposes
+    #[clap(long)]
+    debug: bool,
 }
 
 #[derive(Subcommand)]
@@ -128,12 +131,15 @@ fn main() {
         writeln!(buf, "{}", indented)
     };
 
-    builder
-        .format(log_format)
-        .filter(None, log::LevelFilter::Info)
-        .init();
-
     let cli = Cli::parse();
+
+    let log_level = if cli.debug {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+
+    builder.format(log_format).filter(None, log_level).init();
 
     match &cli.commands {
         Some(Commands::Add { repo, overwrite }) => commands::add(repo, *overwrite),

--- a/src/plan/action.rs
+++ b/src/plan/action.rs
@@ -42,18 +42,27 @@ impl Action {
 
         match self {
             CreateDir(path) => {
-                let was_created = fs.create_directory(path)
+                let was_created = fs
+                    .create_directory(path)
                     .with_context(|| format!("Failed to create directory {}", path))?;
                 if was_created {
-                    fs.track_directory(path)
-                        .with_context(|| format!("Failed to update {}", utils::fs::pretty_path(fs.footprint_path())))?;
+                    fs.track_directory(path).with_context(|| {
+                        format!(
+                            "Failed to update {}",
+                            utils::fs::pretty_path(fs.footprint_path())
+                        )
+                    })?;
                 }
             }
             CreateLink(link) => {
                 fs.create_symlink(link)
                     .with_context(|| format!("Failed to create symlink {}", link))?;
-                fs.track_symlink(link)
-                    .with_context(|| format!("Failed to update {}", utils::fs::pretty_path(fs.footprint_path())))?;
+                fs.track_symlink(link).with_context(|| {
+                    format!(
+                        "Failed to update {}",
+                        utils::fs::pretty_path(fs.footprint_path())
+                    )
+                })?;
             }
             RemoveFile(path) => {
                 fs.remove_file(path)
@@ -64,8 +73,12 @@ impl Action {
                     .with_context(|| format!("Failed to remove directory {}", path))?;
             }
             RemoveLink(link) => {
-                fs.remove_symlink(link)
-                    .with_context(|| format!("Failed to remove symlink at {}", utils::fs::pretty_path(&link.dest.path)))?;
+                fs.remove_symlink(link).with_context(|| {
+                    format!(
+                        "Failed to remove symlink at {}",
+                        utils::fs::pretty_path(&link.dest.path)
+                    )
+                })?;
             }
         };
         Ok(())

--- a/src/plan/action.rs
+++ b/src/plan/action.rs
@@ -41,10 +41,10 @@ impl Action {
         use Action::*;
 
         match self {
-            CreateDir(path) => std::fs::create_dir_all(path)?,
+            CreateDir(path) => fs.create_directory(path)?,
             CreateLink(link) => fs.create_symlink(link)?,
-            RemoveFile(path) => std::fs::remove_file(path)?,
-            RemoveDir(path) => std::fs::remove_dir_all(path)?,
+            RemoveFile(path) => fs.remove_file(path)?,
+            RemoveDir(path) => fs.remove_directory(path)?,
             RemoveLink(link) => fs.remove_symlink(link)?,
         };
         Ok(())

--- a/src/plan/action.rs
+++ b/src/plan/action.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use camino::Utf8PathBuf;
 
 use crate::fs_manager::FSManager;
@@ -41,23 +42,30 @@ impl Action {
 
         match self {
             CreateDir(path) => {
-                let was_created = fs.create_directory(path)?;
+                let was_created = fs.create_directory(path)
+                    .with_context(|| format!("Failed to create directory {}", path))?;
                 if was_created {
-                    fs.track_directory(path)?;
+                    fs.track_directory(path)
+                        .with_context(|| format!("Failed to update {}", utils::fs::pretty_path(fs.footprint_path())))?;
                 }
             }
             CreateLink(link) => {
-                fs.create_symlink(link)?;
-                fs.track_symlink(link)?;
+                fs.create_symlink(link)
+                    .with_context(|| format!("Failed to create symlink {}", link))?;
+                fs.track_symlink(link)
+                    .with_context(|| format!("Failed to update {}", utils::fs::pretty_path(fs.footprint_path())))?;
             }
             RemoveFile(path) => {
-                fs.remove_file(path)?;
+                fs.remove_file(path)
+                    .with_context(|| format!("Failed to remove file {}", path))?;
             }
             RemoveDir(path) => {
-                fs.remove_directory(path)?;
+                fs.remove_directory(path)
+                    .with_context(|| format!("Failed to remove directory {}", path))?;
             }
             RemoveLink(link) => {
-                fs.remove_symlink(link)?;
+                fs.remove_symlink(link)
+                    .with_context(|| format!("Failed to remove symlink at {}", utils::fs::pretty_path(&link.dest.path)))?;
             }
         };
         Ok(())

--- a/src/plan/action.rs
+++ b/src/plan/action.rs
@@ -1,0 +1,73 @@
+use camino::Utf8PathBuf;
+
+use crate::fs_manager::FSManager;
+
+use super::links;
+
+/**
+ * # Actions System
+ *
+ * Actions represent high-level filesystem operations with built-in intelligence.
+ * They serve as an abstraction layer over raw filesystem calls, providing:
+ *
+ * - **Dry-run support**: Generate and inspect actions without executing them
+ * - **Error collection**: Collect multiple errors instead of failing fast
+ * - **Operation inspection**: Debug what filesystem changes will be made
+ * - **Error avoidance**: Skip operations that would produce expected errors
+ *
+ * ## Design Philosophy:
+ * - Actions are **high-level filesystem operations**, not low-level system calls
+ * - Each action can validate itself and decide if it should be skipped
+ * - Actions are generic and can be used by any component needing filesystem operations
+ * - Actions enable better user experience through inspection and error collection
+ */
+#[derive(Debug)]
+pub enum Action {
+    CreateDir(Utf8PathBuf),
+    CreateLink(links::Link),
+    RemoveFile(Utf8PathBuf),
+    RemoveDir(Utf8PathBuf),
+    RemoveLink(links::Link),
+}
+
+impl Action {
+    /**
+     * Executes the filesystem operation represented by this action.
+     *
+     * Performs the actual filesystem changes. Operations that affect symlinks
+     * (CreateLink/RemoveLink) automatically update the footprint tracking.
+     */
+    pub fn execute(&self, fs: &mut FSManager) -> anyhow::Result<()> {
+        use Action::*;
+
+        match self {
+            CreateDir(path) => std::fs::create_dir_all(path)?,
+            CreateLink(link) => fs.create_symlink(link)?,
+            RemoveFile(path) => std::fs::remove_file(path)?,
+            RemoveDir(path) => std::fs::remove_dir_all(path)?,
+            RemoveLink(link) => fs.remove_symlink(link)?,
+        };
+        Ok(())
+    }
+
+    /**
+     * Determines if this action should be skipped to avoid expected filesystem errors.
+     *
+     * This method checks the current filesystem state to avoid operations that would
+     * produce "expected" errors that we'd have to filter out later (like NotFound
+     * when removing non-existent files, or AlreadyExists when creating existing dirs).
+     *
+     * This is primarily about error avoidance, not performance - we want to collect
+     * only "real" errors, not expected errors from no-op operations.
+     */
+    pub fn should_skip(&self) -> bool {
+        use Action::*;
+        match self {
+            CreateDir(path) => path.is_dir(),
+            CreateLink(link) => link.exists(),
+            RemoveFile(path) => !path.is_file(),
+            RemoveDir(path) => !path.is_dir(),
+            RemoveLink(link) => !link.dest.exists(),
+        }
+    }
+}

--- a/src/plan/action.rs
+++ b/src/plan/action.rs
@@ -31,35 +31,46 @@ pub enum Action {
 }
 
 impl Action {
-    /**
-     * Executes the filesystem operation represented by this action.
-     *
-     * Performs the actual filesystem changes. Operations that affect symlinks
-     * (CreateLink/RemoveLink) automatically update the footprint tracking.
-     */
+    /// Executes the filesystem operation represented by this action.
+    ///
+    /// Orchestrates FSManager primitives to perform filesystem changes and footprint tracking:
+    /// - Creations (CreateDir, CreateLink) are always tracked in the footprint
+    /// - Removals (RemoveLink, RemoveDir, RemoveFile) only touch filesystem, footprint is reconciled later
     pub fn execute(&self, fs: &mut FSManager) -> anyhow::Result<()> {
         use Action::*;
 
         match self {
-            CreateDir(path) => fs.create_directory(path)?,
-            CreateLink(link) => fs.create_symlink(link)?,
-            RemoveFile(path) => fs.remove_file(path)?,
-            RemoveDir(path) => fs.remove_directory(path)?,
-            RemoveLink(link) => fs.remove_symlink(link)?,
+            CreateDir(path) => {
+                let was_created = fs.create_directory(path)?;
+                if was_created {
+                    fs.track_directory(path)?;
+                }
+            }
+            CreateLink(link) => {
+                fs.create_symlink(link)?;
+                fs.track_symlink(link)?;
+            }
+            RemoveFile(path) => {
+                fs.remove_file(path)?;
+            }
+            RemoveDir(path) => {
+                fs.remove_directory(path)?;
+            }
+            RemoveLink(link) => {
+                fs.remove_symlink(link)?;
+            }
         };
         Ok(())
     }
 
-    /**
-     * Determines if this action should be skipped to avoid expected filesystem errors.
-     *
-     * This method checks the current filesystem state to avoid operations that would
-     * produce "expected" errors that we'd have to filter out later (like NotFound
-     * when removing non-existent files, or AlreadyExists when creating existing dirs).
-     *
-     * This is primarily about error avoidance, not performance - we want to collect
-     * only "real" errors, not expected errors from no-op operations.
-     */
+    /// Determines if this action should be skipped to avoid expected filesystem errors.
+    ///
+    /// This method checks the current filesystem state to avoid operations that would
+    /// produce "expected" errors that we'd have to filter out later (like NotFound
+    /// when removing non-existent files, or AlreadyExists when creating existing dirs).
+    ///
+    /// This is primarily about error avoidance, not performance - we want to collect
+    /// only "real" errors, not expected errors from no-op operations.
     pub fn should_skip(&self) -> bool {
         use Action::*;
         match self {

--- a/src/plan/links.rs
+++ b/src/plan/links.rs
@@ -25,7 +25,9 @@ impl Link {
     }
 
     pub fn exists(&self) -> bool {
-        let Ok(path) = fs::read_link(&self.dest.path) else { return false };
+        let Ok(path) = fs::read_link(&self.dest.path) else {
+            return false;
+        };
         path == self.src.path
     }
 }

--- a/src/plan/links.rs
+++ b/src/plan/links.rs
@@ -68,6 +68,10 @@ impl Anchor {
             kind: AnchorKind::Destination,
         }
     }
+
+    pub fn exists(&self) -> bool {
+        self.path.is_symlink()
+    }
 }
 
 #[derive(Eq, PartialEq, Clone, Debug, PartialOrd, Ord)]

--- a/src/plan/links.rs
+++ b/src/plan/links.rs
@@ -36,6 +36,17 @@ impl fmt::Debug for Link {
     }
 }
 
+impl fmt::Display for Link {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} => {}",
+            utils::fs::pretty_path(&self.dest.path),
+            utils::fs::pretty_path(&self.src.path)
+        )
+    }
+}
+
 /*=========*\
 *  Anchors  *
 \*=========*/

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -1,5 +1,6 @@
 pub use self::plan::Plan;
 
+pub mod action;
 pub mod links;
 pub mod plan;
 pub mod resolve;

--- a/src/plan/plan.rs
+++ b/src/plan/plan.rs
@@ -1,14 +1,24 @@
+/**
+ * # Plan Module
+ *
+ * The Plan orchestrates dotfiles operations through three phases:
+ * clean (footprint maintenance) → validate (conflict detection) → execute (installation).
+ *
+ * Uses the Actions system for filesystem operations to enable dry-run support,
+ * error collection, and operation inspection.
+ */
+
 use crate::dots::{Dot, Environment};
 use crate::fs_manager::FSManager;
 use crate::plan::resolve::{ResolveIssueKind, ResolvedLink};
 use anyhow::Result;
 use camino::Utf8Path;
-use std::fs;
 use std::{
     fmt::{self, Display},
     io,
 };
 
+use super::action::Action;
 use super::links::Link;
 use super::resolve::{ResolveIssue, ResolveIssueLevel};
 
@@ -60,16 +70,75 @@ impl Plan {
         }
     }
 
+    /**
+     * Cleans up stale footprint entries and broken symlinks.
+     *
+     * This method performs footprint maintenance by:
+     * 1. Removing footprint entries for symlinks that were manually deleted
+     * 2. Removing stale symlinks that point to incorrect targets and their footprint entries
+     * 3. Removing footprint entries for symlinks pointing outside the dots directory
+     * 4. Removing symlinks that are no longer present in any dot.toml and their footprint entries
+     */
     pub fn clean(&self, env: &Environment, fs_manager: &mut FSManager, dots: &[Dot]) -> Result<()> {
         let links: Vec<Link> = dots
             .iter()
             .flat_map(|dot| &dot.links)
             .filter_map(|resolved_link| resolved_link.as_link())
             .collect();
-        fs_manager.clean(&links, env)?;
+
+        let mut fs_actions: Vec<Action> = vec![];
+        let mut footprint_removals: Vec<Link> = vec![];
+
+        // Generate cleanup actions based on footprint vs reality
+        for footprint_link in fs_manager.footprint.links.iter().cloned() {
+            if !footprint_link.dest.path.is_symlink() {
+                debug!("no symlink detected, removing footprint link");
+                // Symlink was deleted manually, just clean footprint
+                footprint_removals.push(footprint_link);
+            } else if !footprint_link.exists() {
+                debug!("symlink detected, but pointing to wrong dest, removing symlink and footprint link");
+                // Stale symlink pointing to wrong target, remove it and clean footprint
+                fs_actions.push(Action::RemoveLink(footprint_link.clone()));
+                footprint_removals.push(footprint_link);
+            } else if !footprint_link.src.path.starts_with(env.root()) {
+                debug!("symlink exists, but source is outside of dots dir, removing footprint link");
+                // Symlink points outside dots directory, just clean footprint
+                footprint_removals.push(footprint_link);
+            } else if !links.contains(&footprint_link) {
+                debug!("symlink exists, but not in any dot toml, removing symlink and footprint link");
+                // Symlink exists but not in any current dot.toml, remove it and clean footprint
+                fs_actions.push(Action::RemoveLink(footprint_link.clone()));
+                footprint_removals.push(footprint_link);
+            }
+        }
+
+        debug!("CLEANUP ACTIONS");
+
+        // Execute filesystem actions with skip logic
+        for action in fs_actions {
+            let should_skip = action.should_skip();
+            debug!("skip: {}, action: {:?}", should_skip, action);
+            if !should_skip {
+                action.execute(fs_manager)?;
+            }
+        }
+
+        // Update footprint entries directly
+        for link in footprint_removals {
+            fs_manager.remove_footprint_link(&link)?;
+        }
         Ok(())
     }
 
+    /**
+     * Validates the dotfiles installation plan and detects conflicts.
+     *
+     * Uses the ResolvedLink system to check for missing files, conflicting symlinks,
+     * permission issues, and duplicate destinations. Shows warnings and errors
+     * to the user before any filesystem changes are made.
+     *
+     * Returns Ok if the plan can proceed, or Err if there are unresolved issues.
+     */
     pub fn validate(&mut self, dots: Vec<Dot>) -> Result<(), PlanError> {
         let mut suggest_force = false;
         let mut fixed_issues: Vec<&ResolveIssue> = vec![];
@@ -150,6 +219,16 @@ impl Plan {
         }
     }
 
+    /**
+     * Executes the dotfiles installation using the Actions system.
+     *
+     * Trusts that validation has passed and performs the actual filesystem operations
+     * to install dotfiles. Uses Actions to create directories, symlinks, and remove
+     * conflicting files (when force=true).
+     *
+     * Collects multiple errors instead of failing fast to provide comprehensive
+     * feedback about what went wrong during installation.
+     */
     pub fn execute(&self, fs_manager: &mut FSManager, force: bool) -> Result<()> {
         let links: Vec<Link> = self
             .links
@@ -157,9 +236,11 @@ impl Plan {
             .filter_map(|resolved_link| resolved_link.as_link())
             .collect();
 
+        let mut actions: Vec<Action> = vec![];
+
         for link in links {
             if link.dest.path.is_symlink() {
-                fs_manager.remove_symlink(&link)?;
+                actions.push(Action::RemoveLink(link.clone()));
             } else if link.dest.path.is_file() {
                 if !force {
                     return Err(anyhow::Error::new(io::Error::new(
@@ -168,7 +249,7 @@ impl Plan {
                     )));
                 }
 
-                fs::remove_file(&link.dest.path)?;
+                actions.push(Action::RemoveFile(link.dest.path.clone()));
             } else if link.dest.path.is_dir() {
                 if !force {
                     return Err(anyhow::Error::new(io::Error::new(
@@ -177,15 +258,43 @@ impl Plan {
                     )));
                 }
 
-                fs::remove_dir_all(&link.dest.path)?;
+                actions.push(Action::RemoveDir(link.dest.path.clone()));
             }
 
             if let Some(parent) = link.dest.path.parent() {
-                fs::create_dir_all(parent)?;
+                actions.push(Action::CreateDir(parent.to_owned()));
             }
 
-            fs_manager.create_symlink(&link)?;
+            actions.push(Action::CreateLink(link.clone()));
         }
+
+        debug!("ACTIONS");
+
+        /*
+         * TODO:
+         * I want a list of errors produced from different actions
+         * I want a list of actions produced from different links
+         * can we have 1 action connected to multiple links?
+         * if so that means we can have 1 error connected to multiple links as well
+         */
+
+        let mut errors: Vec<anyhow::Error> = vec![];
+
+        for action in actions {
+            let should_skip = action.should_skip();
+            debug!("skip: {}, action: {:?}", should_skip, action);
+            if should_skip {
+                continue;
+            }
+            if let Some(error) = action.execute(fs_manager).err() {
+                errors.push(error)
+            }
+        }
+
+        if let Some(error) = errors.pop() {
+            return Err(error);
+        }
+
         Ok(())
     }
 

--- a/src/plan/plan.rs
+++ b/src/plan/plan.rs
@@ -7,7 +7,6 @@
  * Uses the Actions system for filesystem operations to enable dry-run support,
  * error collection, and operation inspection.
  */
-
 use crate::dots::{Dot, Environment};
 use crate::fs_manager::FSManager;
 use crate::plan::resolve::{ResolveIssueKind, ResolvedLink};
@@ -79,7 +78,13 @@ impl Plan {
     ///
     /// After cleanup, reconciles the footprint by removing stale entries and warning
     /// about directories that can't be removed due to user files.
-    pub fn clean(&self, env: &Environment, fs_manager: &mut FSManager, dots: &[Dot], dry_run: bool) -> Result<()> {
+    pub fn clean(
+        &self,
+        env: &Environment,
+        fs_manager: &mut FSManager,
+        dots: &[Dot],
+        dry_run: bool,
+    ) -> Result<()> {
         let current_links: Vec<Link> = dots
             .iter()
             .flat_map(|dot| &dot.links)
@@ -121,7 +126,9 @@ impl Plan {
             .dirs
             .iter()
             .filter(|dir_path| {
-                let is_needed = current_links.iter().any(|link| link.dest.path.starts_with(dir_path));
+                let is_needed = current_links
+                    .iter()
+                    .any(|link| link.dest.path.starts_with(dir_path));
 
                 if !is_needed && dir_path.is_dir() {
                     // Check if has user files
@@ -159,9 +166,9 @@ impl Plan {
             // Remove directories that don't exist or aren't needed by current links
             footprint.dirs.retain(|dir_path| {
                 let dir_exists = dir_path.is_dir();
-                let is_needed = current_links.iter().any(|link| {
-                    link.dest.path.starts_with(dir_path)
-                });
+                let is_needed = current_links
+                    .iter()
+                    .any(|link| link.dest.path.starts_with(dir_path));
 
                 dir_exists && is_needed
             });
@@ -269,7 +276,12 @@ impl Plan {
     ///
     /// Collects multiple errors instead of failing fast to provide comprehensive
     /// feedback about what went wrong during installation.
-    pub fn execute(&self, _env: &Environment, fs_manager: &mut FSManager, force: bool) -> Result<()> {
+    pub fn execute(
+        &self,
+        _env: &Environment,
+        fs_manager: &mut FSManager,
+        force: bool,
+    ) -> Result<()> {
         let links: Vec<Link> = self
             .links
             .iter()
@@ -372,14 +384,18 @@ impl Plan {
             .collect()
     }
 
-
     /// Generates cleanup actions for stale symlinks and empty directories.
     ///
     /// Returns actions that need to be executed to clean up the filesystem based on:
     /// - Symlinks in footprint that don't exist anymore or point to wrong targets
     /// - Symlinks in footprint that aren't in current dot.toml files
     /// - Empty tracked directories that aren't needed by current links
-    fn generate_cleanup_actions(&self, env: &Environment, fs_manager: &FSManager, current_links: &[Link]) -> Vec<Action> {
+    fn generate_cleanup_actions(
+        &self,
+        env: &Environment,
+        fs_manager: &FSManager,
+        current_links: &[Link],
+    ) -> Vec<Action> {
         let mut actions = vec![];
 
         // Clean up stale symlinks
@@ -408,9 +424,9 @@ impl Plan {
             if dir_path.is_dir() && !Self::directory_contains_files(dir_path, fs_manager) {
                 // Directory is empty and exists
                 // Check if any current links still need this directory
-                let still_needed = current_links.iter().any(|link| {
-                    link.dest.path.starts_with(dir_path)
-                });
+                let still_needed = current_links
+                    .iter()
+                    .any(|link| link.dest.path.starts_with(dir_path));
 
                 if !still_needed {
                     actions.push(Action::RemoveDir(dir_path.clone()));

--- a/src/plan/plan.rs
+++ b/src/plan/plan.rs
@@ -70,135 +70,126 @@ impl Plan {
         }
     }
 
-    /**
-     * Cleans up stale footprint entries and broken symlinks.
-     *
-     * This method performs footprint maintenance by:
-     * 1. Removing footprint entries for symlinks that were manually deleted
-     * 2. Removing stale symlinks that point to incorrect targets and their footprint entries
-     * 3. Removing footprint entries for symlinks pointing outside the dots directory
-     * 4. Removing symlinks that are no longer present in any dot.toml and their footprint entries
-     */
-    pub fn clean(&self, env: &Environment, fs_manager: &mut FSManager, dots: &[Dot]) -> Result<()> {
-        let links: Vec<Link> = dots
+    /// Cleans up stale symlinks and empty directories, then reconciles the footprint.
+    ///
+    /// Generates and executes cleanup actions for:
+    /// - Symlinks in footprint that no longer exist or point to wrong targets
+    /// - Symlinks in footprint that aren't in current dot.toml files
+    /// - Empty tracked directories that aren't needed by current links
+    ///
+    /// After cleanup, reconciles the footprint by removing stale entries and warning
+    /// about directories that can't be removed due to user files.
+    pub fn clean(&self, env: &Environment, fs_manager: &mut FSManager, dots: &[Dot], dry_run: bool) -> Result<()> {
+        let current_links: Vec<Link> = dots
             .iter()
             .flat_map(|dot| &dot.links)
             .filter_map(|resolved_link| resolved_link.as_link())
             .collect();
 
-        let mut fs_actions: Vec<Action> = vec![];
-        let mut footprint_removals: Vec<Link> = vec![];
+        // Generate cleanup actions
+        let cleanup_actions = self.generate_cleanup_actions(env, fs_manager, &current_links);
 
-        // Generate cleanup actions based on footprint vs reality
-        for footprint_link in fs_manager.footprint.links.iter().cloned() {
-            if !footprint_link.dest.path.is_symlink() {
-                debug!("no symlink detected, removing footprint link");
-                // Symlink was deleted manually, just clean footprint
-                footprint_removals.push(footprint_link);
-            } else if !footprint_link.exists() {
-                debug!("symlink detected, but pointing to wrong dest, removing symlink and footprint link");
-                // Stale symlink pointing to wrong target, remove it and clean footprint
-                fs_actions.push(Action::RemoveLink(footprint_link.clone()));
-                footprint_removals.push(footprint_link);
-            } else if !footprint_link.src.path.starts_with(env.root()) {
-                debug!("symlink exists, but source is outside of dots dir, removing footprint link");
-                // Symlink points outside dots directory, just clean footprint
-                footprint_removals.push(footprint_link);
-            } else if !links.contains(&footprint_link) {
-                debug!("symlink exists, but not in any dot toml, removing symlink and footprint link");
-                // Symlink exists but not in any current dot.toml, remove it and clean footprint
-                fs_actions.push(Action::RemoveLink(footprint_link.clone()));
-                footprint_removals.push(footprint_link);
+        if dry_run {
+            // Just log what would be cleaned up
+            debug!("DRY RUN - Cleanup actions that would be executed:");
+            for action in &cleanup_actions {
+                debug!("  {:?}", action);
             }
-        }
-
-        debug!("CLEANUP ACTIONS");
-
-        // Execute filesystem actions with skip logic
-        for action in fs_actions {
-            let should_skip = action.should_skip();
-            debug!("skip: {}, action: {:?}", should_skip, action);
-            if !should_skip {
-                action.execute(fs_manager)?;
-            }
-        }
-
-        // Clean up tracked directories that are now empty
-        let mut tracked_dirs: Vec<_> = fs_manager.footprint.dirs.iter().cloned().collect();
-        // Sort by depth (deepest first) to handle nested directories correctly
-        tracked_dirs.sort_by_key(|b| std::cmp::Reverse(b.components().count()));
-
-        let mut dir_removals: Vec<camino::Utf8PathBuf> = vec![];
-        for dir_path in tracked_dirs {
-            if dir_path.is_dir() {
-                match std::fs::read_dir(&dir_path) {
-                    Ok(mut entries) => {
-                        if entries.next().is_none() {
-                            // Directory is empty - try to remove
-                            let remove_action = Action::RemoveDir(dir_path.clone());
-                            if !remove_action.should_skip() {
-                                match remove_action.execute(fs_manager) {
-                                    Ok(_) => {
-                                        // Successfully removed
-                                        dir_removals.push(dir_path);
-                                    }
-                                    Err(err) => {
-                                        // Failed to remove empty directory (permissions?)
-                                        warn!("Unable to remove empty directory {}: {}", dir_path, err);
-                                        warn!("You may need to remove it manually with appropriate permissions");
-                                        // Keep tracking - don't add to dir_removals
-                                    }
-                                }
-                            }
-                        } else {
-                            // Directory contains files - stop tracking it
-                            // The user has claimed this directory for their own use
-                            dir_removals.push(dir_path);
+        } else {
+            // Execute cleanup actions
+            debug!("CLEANUP ACTIONS");
+            for action in cleanup_actions {
+                let should_skip = action.should_skip();
+                debug!("skip: {}, action: {:?}", should_skip, action);
+                if !should_skip {
+                    match action.execute(fs_manager) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            // Log error but continue with other cleanup actions
+                            warn!("Cleanup action failed: {}", err);
+                            warn!("You may need to clean up manually");
                         }
                     }
-                    Err(err) => {
-                        // Can't read directory (permissions?)
-                        warn!("Unable to access directory {} for cleanup: {}", dir_path, err);
-                        warn!("You may need to check permissions or remove it manually");
-                        // Keep tracking - don't add to dir_removals
-                    }
                 }
-            } else {
-                // Directory doesn't exist - stop tracking
-                dir_removals.push(dir_path);
             }
         }
 
-        // Update footprint entries directly
-        for link in footprint_removals {
-            fs_manager.remove_footprint_link(&link)?;
+        // Reconcile footprint after cleanup
+        // Check for directories with user files before reconciliation
+        let dirs_with_user_files: Vec<_> = fs_manager
+            .footprint
+            .dirs
+            .iter()
+            .filter(|dir_path| {
+                let is_needed = current_links.iter().any(|link| link.dest.path.starts_with(dir_path));
+
+                if !is_needed && dir_path.is_dir() {
+                    // Check if has user files
+                    fs_manager
+                        .read_dir(dir_path)
+                        .ok()
+                        .map(|entries| {
+                            entries.filter_map(|e| e.ok()).any(|entry| {
+                                let path = entry.path();
+                                path.is_file() && !path.is_symlink()
+                            })
+                        })
+                        .unwrap_or(false)
+                } else {
+                    false
+                }
+            })
+            .cloned()
+            .collect();
+
+        // Warn about directories we can't remove
+        for dir_path in &dirs_with_user_files {
+            warn!(
+                "Cannot remove directory {} - it contains files that were not created by dots",
+                utils::fs::pretty_path(dir_path)
+            );
         }
 
-        // Remove cleaned directories from footprint tracking
-        for dir_path in dir_removals {
-            fs_manager.remove_footprint_dir(&dir_path)?;
-        }
+        fs_manager.edit_footprint(|footprint| {
+            // Remove links that don't exist or point outside dots directory
+            footprint.links.retain(|link| {
+                link.dest.path.is_symlink() && link.src.path.starts_with(env.root())
+            });
+
+            // Remove directories that don't exist or aren't needed by current links
+            footprint.dirs.retain(|dir_path| {
+                let dir_exists = dir_path.is_dir();
+                let is_needed = current_links.iter().any(|link| {
+                    link.dest.path.starts_with(dir_path)
+                });
+
+                dir_exists && is_needed
+            });
+        })?;
+
         Ok(())
     }
 
-    /**
-     * Validates the dotfiles installation plan and detects conflicts.
-     *
-     * Uses the ResolvedLink system to check for missing files, conflicting symlinks,
-     * permission issues, and duplicate destinations. Shows warnings and errors
-     * to the user before any filesystem changes are made.
-     *
-     * Returns Ok if the plan can proceed, or Err if there are unresolved issues.
-     */
-    pub fn validate(&mut self, dots: Vec<Dot>) -> Result<(), PlanError> {
+    /// Validates the dotfiles installation plan and detects conflicts.
+    ///
+    /// Uses the ResolvedLink system to check for missing files, conflicting symlinks,
+    /// permission issues, and duplicate destinations. Shows warnings and errors
+    /// to the user before any filesystem changes are made.
+    ///
+    /// Returns Ok if the plan can proceed, or Err if there are unresolved issues.
+    pub fn validate(&mut self, dots: &[Dot]) -> Result<(), PlanError> {
         let mut suggest_force = false;
         let mut fixed_issues: Vec<&ResolveIssue> = vec![];
-        for dot in dots {
+        for (index, dot) in dots.iter().enumerate() {
             let title = format!("[{name}]", name = &dot.package.name);
-            eprintln!("\n{title}", title = styles::TITLE.apply(title));
-            let links = dot.links;
+            if index > 0 {
+                eprintln!();
+            }
+            eprintln!("{title}", title = styles::TITLE.apply(title));
+            let links = &dot.links;
 
-            for mut link in links {
+            for link in links {
+                let mut link = link.clone();
                 if let Some(resolved_dest) = &link.dest.path {
                     let duplicates = self.duplicates(resolved_dest);
                     if !duplicates.is_empty() {
@@ -270,17 +261,15 @@ impl Plan {
         }
     }
 
-    /**
-     * Executes the dotfiles installation using the Actions system.
-     *
-     * Trusts that validation has passed and performs the actual filesystem operations
-     * to install dotfiles. Uses Actions to create directories, symlinks, and remove
-     * conflicting files (when force=true).
-     *
-     * Collects multiple errors instead of failing fast to provide comprehensive
-     * feedback about what went wrong during installation.
-     */
-    pub fn execute(&self, fs_manager: &mut FSManager, force: bool) -> Result<()> {
+    /// Executes the dotfiles installation using the Actions system.
+    ///
+    /// Trusts that validation has passed and performs the actual filesystem operations
+    /// to install dotfiles. Uses Actions to create directories, symlinks, and remove
+    /// conflicting files (when force=true).
+    ///
+    /// Collects multiple errors instead of failing fast to provide comprehensive
+    /// feedback about what went wrong during installation.
+    pub fn execute(&self, _env: &Environment, fs_manager: &mut FSManager, force: bool) -> Result<()> {
         let links: Vec<Link> = self
             .links
             .iter()
@@ -289,7 +278,7 @@ impl Plan {
 
         let mut actions: Vec<Action> = vec![];
 
-        for link in links {
+        for link in &links {
             if link.dest.path.is_symlink() {
                 actions.push(Action::RemoveLink(link.clone()));
             } else if link.dest.path.is_file() {
@@ -381,5 +370,63 @@ impl Plan {
             .into_iter()
             .filter(|&issue| matches!(issue.level(), ResolveIssueLevel::Error))
             .collect()
+    }
+
+
+    /// Generates cleanup actions for stale symlinks and empty directories.
+    ///
+    /// Returns actions that need to be executed to clean up the filesystem based on:
+    /// - Symlinks in footprint that don't exist anymore or point to wrong targets
+    /// - Symlinks in footprint that aren't in current dot.toml files
+    /// - Empty tracked directories that aren't needed by current links
+    fn generate_cleanup_actions(&self, env: &Environment, fs_manager: &FSManager, current_links: &[Link]) -> Vec<Action> {
+        let mut actions = vec![];
+
+        // Clean up stale symlinks
+        for footprint_link in &fs_manager.footprint.links {
+            // Skip links that point outside dots directory - they're not ours to manage
+            if !footprint_link.src.path.starts_with(env.root()) {
+                continue;
+            }
+
+            if footprint_link.dest.path.is_symlink() {
+                if !footprint_link.exists() {
+                    // Stale symlink pointing to wrong target
+                    actions.push(Action::RemoveLink(footprint_link.clone()));
+                } else if !current_links.contains(footprint_link) {
+                    // Symlink not in current dot.toml
+                    actions.push(Action::RemoveLink(footprint_link.clone()));
+                }
+            }
+        }
+
+        // Clean up empty directories (sort by depth, deepest first)
+        let mut tracked_dirs: Vec<_> = fs_manager.footprint.dirs.iter().collect();
+        tracked_dirs.sort_by_key(|dir| std::cmp::Reverse(dir.components().count()));
+
+        for dir_path in tracked_dirs {
+            if dir_path.is_dir() && !Self::directory_contains_files(dir_path, fs_manager) {
+                // Directory is empty and exists
+                // Check if any current links still need this directory
+                let still_needed = current_links.iter().any(|link| {
+                    link.dest.path.starts_with(dir_path)
+                });
+
+                if !still_needed {
+                    actions.push(Action::RemoveDir(dir_path.clone()));
+                }
+            }
+        }
+
+        actions
+    }
+
+    /// Checks if a directory contains any files (not empty or only has subdirs)
+    fn directory_contains_files(dir_path: &Utf8Path, fs_manager: &FSManager) -> bool {
+        if let Ok(entries) = fs_manager.read_dir(dir_path) {
+            entries.count() > 0
+        } else {
+            false
+        }
     }
 }

--- a/src/plan/plan.rs
+++ b/src/plan/plan.rs
@@ -123,9 +123,60 @@ impl Plan {
             }
         }
 
+        // Clean up tracked directories that are now empty
+        let mut tracked_dirs: Vec<_> = fs_manager.footprint.dirs.iter().cloned().collect();
+        // Sort by depth (deepest first) to handle nested directories correctly
+        tracked_dirs.sort_by_key(|b| std::cmp::Reverse(b.components().count()));
+
+        let mut dir_removals: Vec<camino::Utf8PathBuf> = vec![];
+        for dir_path in tracked_dirs {
+            if dir_path.is_dir() {
+                match std::fs::read_dir(&dir_path) {
+                    Ok(mut entries) => {
+                        if entries.next().is_none() {
+                            // Directory is empty - try to remove
+                            let remove_action = Action::RemoveDir(dir_path.clone());
+                            if !remove_action.should_skip() {
+                                match remove_action.execute(fs_manager) {
+                                    Ok(_) => {
+                                        // Successfully removed
+                                        dir_removals.push(dir_path);
+                                    }
+                                    Err(err) => {
+                                        // Failed to remove empty directory (permissions?)
+                                        warn!("Unable to remove empty directory {}: {}", dir_path, err);
+                                        warn!("You may need to remove it manually with appropriate permissions");
+                                        // Keep tracking - don't add to dir_removals
+                                    }
+                                }
+                            }
+                        } else {
+                            // Directory contains files - stop tracking it
+                            // The user has claimed this directory for their own use
+                            dir_removals.push(dir_path);
+                        }
+                    }
+                    Err(err) => {
+                        // Can't read directory (permissions?)
+                        warn!("Unable to access directory {} for cleanup: {}", dir_path, err);
+                        warn!("You may need to check permissions or remove it manually");
+                        // Keep tracking - don't add to dir_removals
+                    }
+                }
+            } else {
+                // Directory doesn't exist - stop tracking
+                dir_removals.push(dir_path);
+            }
+        }
+
         // Update footprint entries directly
         for link in footprint_removals {
             fs_manager.remove_footprint_link(&link)?;
+        }
+
+        // Remove cleaned directories from footprint tracking
+        for dir_path in dir_removals {
+            fs_manager.remove_footprint_dir(&dir_path)?;
         }
         Ok(())
     }

--- a/src/plan/resolve.rs
+++ b/src/plan/resolve.rs
@@ -56,7 +56,7 @@ where
             let issue_kind = match err.kind() {
                 io::NotFound => link::NotFound,
                 io::PermissionDenied => link::PermissionDenied,
-                _ => link::IO(err),
+                _ => link::IO(err.to_string()),
             };
 
             let issue = ResolveIssue::new(&src.original, issue_kind);
@@ -131,7 +131,7 @@ fn resolve_dest(anchor: Anchor, src: &ResolvedAnchor) -> ResolvedAnchor {
 \*================*/
 
 /// A Link where both the symlink and dotfile path have been resolved and checked for issues
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct ResolvedLink {
     /// The resolved anchor for the dotfile
     pub src: ResolvedAnchor,
@@ -210,7 +210,7 @@ impl Display for ResolvedLink {
 
 /// A ResolvedAnchor is an Anchor whos path has been cannonicalized and checked for potential issues.
 /// Any issues that are found are collected for reporting back to the user.
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct ResolvedAnchor {
     /// Resolved path. If the path is not a valid FS path it will be `None`
     pub path: Option<Utf8PathBuf>,
@@ -279,7 +279,7 @@ impl ResolvedAnchor {
  * the user. Errors should stop the install in its tracks.
  */
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct ResolveIssue {
     pub kind: ResolveIssueKind,
     pub anchor: Anchor,
@@ -291,14 +291,14 @@ pub enum ResolveIssueLevel {
     Warning,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ResolveIssueKind {
     Conflict,
     AlreadyExists(fs::FileType),
     InvalidPath(String),
     NotFound,
     PermissionDenied,
-    IO(io::Error),
+    IO(String),
 }
 
 impl Eq for ResolveIssueKind {}
@@ -322,7 +322,7 @@ impl ResolveIssue {
     }
 
     fn io(anchor: &Anchor, error: io::Error) -> Self {
-        Self::new(anchor, ResolveIssueKind::IO(error))
+        Self::new(anchor, ResolveIssueKind::IO(error.to_string()))
     }
 
     pub fn level(&self) -> ResolveIssueLevel {

--- a/src/plan/resolve.rs
+++ b/src/plan/resolve.rs
@@ -183,7 +183,7 @@ impl Display for ResolvedLink {
             _ => false,
         };
 
-        if is_directory {
+        if is_directory && !src_path.ends_with('/') {
             src_path += "/"
         }
 

--- a/src/plan/resolve.rs
+++ b/src/plan/resolve.rs
@@ -156,8 +156,12 @@ impl ResolvedLink {
     }
     /// Returns a simplified link if all paths are valid
     pub fn as_link(&self) -> Option<Link> {
-        let Some(src) = &self.src.path else { return None };
-        let Some(dest) = &self.dest.path else { return None };
+        let Some(src) = &self.src.path else {
+            return None;
+        };
+        let Some(dest) = &self.dest.path else {
+            return None;
+        };
         Some(Link {
             src: Anchor::new_src(src),
             dest: Anchor::new_dest(dest),

--- a/tests/footprints/empty_footprint.toml
+++ b/tests/footprints/empty_footprint.toml
@@ -1,1 +1,2 @@
+dirs = []
 links = []

--- a/tests/footprints/example_dot.toml
+++ b/tests/footprints/example_dot.toml
@@ -1,3 +1,5 @@
+dirs = []
+
 [[links]]
 src = "{HOME}/.dots/example_dot/shell/bashrc"
 dest = "{HOME}/.bashrc"

--- a/tests/footprints/example_dot_with_invalid_link.toml
+++ b/tests/footprints/example_dot_with_invalid_link.toml
@@ -1,3 +1,5 @@
+dirs = []
+
 [[links]]
 src = "{HOME}/.bashrc"
 dest = "{HOME}/.bash_profile"

--- a/tests/footprints/example_dot_with_link_added.toml
+++ b/tests/footprints/example_dot_with_link_added.toml
@@ -1,3 +1,5 @@
+dirs = []
+
 [[links]]
 src = "{HOME}/.dots/example_dot/shell/bash_profile"
 dest = "{HOME}/.bash_profile"

--- a/tests/footprints/example_dot_with_unlinked_file.toml
+++ b/tests/footprints/example_dot_with_unlinked_file.toml
@@ -1,3 +1,5 @@
+dirs = []
+
 [[links]]
 src = "{HOME}/.dots/example_dot/shell/zshrc"
 dest = "{HOME}/.zshrc"

--- a/tests/output/help.out
+++ b/tests/output/help.out
@@ -3,9 +3,10 @@ Michael Mullins <michael@webdesserts.com>
 A cli for managing all your dot(file)s
 
 USAGE:
-    dots [SUBCOMMAND]
+    dots [OPTIONS] [SUBCOMMAND]
 
 OPTIONS:
+        --debug      Print extra logs for debugging purposes
     -h, --help       Print help information
     -V, --version    Print version information
 

--- a/tests/output/install_fail_with_conflicts.err
+++ b/tests/output/install_fail_with_conflicts.err
@@ -1,4 +1,3 @@
-
 [conflicting_dot]
 ✔ ~/.bashrc => shell/bashrc
 

--- a/tests/output/install_fail_with_existing_directory_warning.err
+++ b/tests/output/install_fail_with_existing_directory_warning.err
@@ -1,4 +1,3 @@
-
 [example_dot]
 ✔ ~/.bashrc => shell/bashrc
 ✔ ~/.zshrc => shell/zshrc

--- a/tests/output/install_fail_with_existing_file_warning.err
+++ b/tests/output/install_fail_with_existing_file_warning.err
@@ -1,4 +1,3 @@
-
 [example_dot]
 ✔ ~/.bashrc => shell/bashrc
 ✔ ~/.zshrc => shell/zshrc

--- a/tests/output/install_fail_with_existing_link_warning.err
+++ b/tests/output/install_fail_with_existing_link_warning.err
@@ -1,4 +1,3 @@
-
 [example_dot]
 ✔ ~/.bashrc => shell/bashrc
 ✔ ~/.zshrc => shell/zshrc

--- a/tests/output/install_fail_with_missing_dotfile.err
+++ b/tests/output/install_fail_with_missing_dotfile.err
@@ -1,4 +1,3 @@
-
 [example_dot]
 ✖ ~/.bashrc => shell/bashrc
 ✔ ~/.zshrc => shell/zshrc

--- a/tests/output/install_fail_with_readonly_footprint.err
+++ b/tests/output/install_fail_with_readonly_footprint.err
@@ -1,0 +1,8 @@
+[example_dot]
+✔ ~/.bashrc => shell/bashrc
+✔ ~/.zshrc => shell/zshrc
+
+[info] Looks Good! Nothing wrong with the current install plan!
+[error] Install Failed!
+[error] Failed to update ~/.dots/dot-footprint.toml
+[error] Permission denied (os error 13)

--- a/tests/output/install_success.err
+++ b/tests/output/install_success.err
@@ -1,4 +1,3 @@
-
 [example_dot]
 ✔ ~/.bashrc => shell/bashrc
 ✔ ~/.zshrc => shell/zshrc

--- a/tests/output/install_success_when_linking_directory.err
+++ b/tests/output/install_success_when_linking_directory.err
@@ -1,4 +1,3 @@
-
 [example_dot_with_directory]
 ✔ ~/bin => bin/
 

--- a/tests/output/install_success_when_self_linking.err
+++ b/tests/output/install_success_when_self_linking.err
@@ -1,4 +1,3 @@
-
 [example_dot_with_self_link]
 ✔ ~/test_self_link => ./
 

--- a/tests/output/install_success_when_self_linking.err
+++ b/tests/output/install_success_when_self_linking.err
@@ -1,0 +1,6 @@
+
+[example_dot_with_self_link]
+✔ ~/test_self_link => ./
+
+[info] Looks Good! Nothing wrong with the current install plan!
+[info] Install was a success!

--- a/tests/output/install_warns_when_directory_has_user_files.err
+++ b/tests/output/install_warns_when_directory_has_user_files.err
@@ -3,3 +3,5 @@
 ✔ ~/.zshrc => shell/zshrc
 
 [info] Looks Good! Nothing wrong with the current install plan!
+[warn] Cannot remove directory ~/.config/zsh - it contains files that were not created by dots
+[info] Install was a success!

--- a/tests/subcommand_install.rs
+++ b/tests/subcommand_install.rs
@@ -778,7 +778,10 @@ mod subcommand_install {
         manager.overwrite_dot(&fixture, &Fixture::ExampleDot)?;
 
         // Run install again which triggers cleanup
-        manager.cmd(BIN)?.arg("install").output()?;
+        let output = manager.cmd(BIN)?.arg("install").output()?;
+
+        // Verify the warning output
+        output.assert_stderr_eq(include_str!("output/install_warns_when_directory_has_user_files.err"));
 
         // The directory should no longer be tracked since it contains user files
         let footprint = manager.read_footprint()?;

--- a/tests/subcommand_install.rs
+++ b/tests/subcommand_install.rs
@@ -714,4 +714,35 @@ mod subcommand_install {
 
         Ok(())
     }
+
+    #[test]
+    fn it_should_display_and_install_the_given_plan_when_a_dot_links_to_itself() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture = Fixture::ExampleDotWithSelfLink;
+        let fixture_path = manager.setup_fixture_as_git_repo(&fixture)?;
+        let dots_root = manager.dots_dir();
+        let home_dir = manager.home_dir();
+
+        manager.cmd(BIN)?.arg("add").arg(&fixture_path).output()?;
+
+        let output = manager.cmd(BIN)?.arg("install").output()?;
+        let expected_err = std::include_str!("output/install_success_when_self_linking.err");
+
+        output
+            .assert_stderr_eq(expected_err)
+            .assert_stdout_eq("")
+            .assert_success();
+
+        let installed_dot_path = dots_root.join(fixture.name());
+
+        assert!(installed_dot_path.is_dir());
+        assert!(installed_dot_path.join("Dot.toml").is_file());
+        assert_eq!(
+            home_dir.join("test_self_link").read_link()?,
+            installed_dot_path
+        );
+
+        Ok(())
+    }
+
 }

--- a/tests/subcommand_install.rs
+++ b/tests/subcommand_install.rs
@@ -753,11 +753,7 @@ mod subcommand_install {
         let home_dir = manager.home_dir();
 
         // Add the dot
-        manager
-            .cmd(BIN)?
-            .arg("add")
-            .arg(&fixture_path)
-            .output()?;
+        manager.cmd(BIN)?.arg("add").arg(&fixture_path).output()?;
 
         // Switch to fixture with nested directories
         manager.overwrite_dot(&fixture, &Fixture::ExampleDotWithNestedDirectories)?;
@@ -781,7 +777,9 @@ mod subcommand_install {
         let output = manager.cmd(BIN)?.arg("install").output()?;
 
         // Verify the warning output
-        output.assert_stderr_eq(include_str!("output/install_warns_when_directory_has_user_files.err"));
+        output.assert_stderr_eq(include_str!(
+            "output/install_warns_when_directory_has_user_files.err"
+        ));
 
         // The directory should no longer be tracked since it contains user files
         let footprint = manager.read_footprint()?;
@@ -794,7 +792,6 @@ mod subcommand_install {
         Ok(())
     }
 
-
     #[test]
     fn it_should_remove_nonexistent_directories_from_tracking() -> TestResult {
         let manager = TestManager::new()?;
@@ -803,11 +800,7 @@ mod subcommand_install {
         let home_dir = manager.home_dir();
 
         // Add the dot
-        manager
-            .cmd(BIN)?
-            .arg("add")
-            .arg(&fixture_path)
-            .output()?;
+        manager.cmd(BIN)?.arg("add").arg(&fixture_path).output()?;
 
         // Switch to fixture with nested directories
         manager.overwrite_dot(&fixture, &Fixture::ExampleDotWithNestedDirectories)?;
@@ -865,5 +858,4 @@ mod subcommand_install {
 
         Ok(())
     }
-
 }

--- a/tests/subcommand_install.rs
+++ b/tests/subcommand_install.rs
@@ -841,4 +841,29 @@ mod subcommand_install {
         Ok(())
     }
 
+    #[test]
+    fn it_should_show_footprint_path_when_permission_denied() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture = Fixture::ExampleDot;
+        let fixture_path = manager.setup_fixture_as_git_repo(&fixture)?;
+
+        // Add the dot and do initial install to create footprint
+        manager.cmd(BIN)?.arg("add").arg(&fixture_path).output()?;
+        manager.cmd(BIN)?.arg("install").output()?;
+
+        // Make footprint readonly to simulate permission denied error
+        manager.make_readonly(manager.footprint_path())?;
+
+        // Try to install again - this will need to update the footprint and fail
+        let output = manager.cmd(BIN)?.arg("install").output()?;
+        let expected_err = std::include_str!("output/install_fail_with_readonly_footprint.err");
+
+        output
+            .assert_stderr_eq(expected_err)
+            .assert_stdout_eq("")
+            .assert_fail();
+
+        Ok(())
+    }
+
 }

--- a/tests/subcommand_install.rs
+++ b/tests/subcommand_install.rs
@@ -745,4 +745,97 @@ mod subcommand_install {
         Ok(())
     }
 
+    #[test]
+    fn it_should_stop_tracking_directories_that_contain_files() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture = Fixture::ExampleDot;
+        let fixture_path = manager.setup_fixture_as_git_repo(&fixture)?;
+        let home_dir = manager.home_dir();
+
+        // Add the dot
+        manager
+            .cmd(BIN)?
+            .arg("add")
+            .arg(&fixture_path)
+            .output()?;
+
+        // Switch to fixture with nested directories
+        manager.overwrite_dot(&fixture, &Fixture::ExampleDotWithNestedDirectories)?;
+
+        // Install the dot - this will create ~/.config/zsh/ directory and track it
+        manager.cmd(BIN)?.arg("install").output()?;
+
+        // Verify the directory was created and check dirs in footprint
+        let tracked_dir = home_dir.join(".config/zsh");
+        assert!(tracked_dir.is_dir());
+        let footprint = manager.read_footprint()?;
+        assert!(footprint.contains(&format!("\"{}\"", tracked_dir))); // Check for quoted path in dirs array
+
+        // User adds their own file to the tracked directory
+        fs::write(tracked_dir.join("zsh_history"), "# command history")?;
+
+        // Switch back to basic fixture (removes nested links)
+        manager.overwrite_dot(&fixture, &Fixture::ExampleDot)?;
+
+        // Run install again which triggers cleanup
+        manager.cmd(BIN)?.arg("install").output()?;
+
+        // The directory should no longer be tracked since it contains user files
+        let footprint = manager.read_footprint()?;
+        assert!(!footprint.contains(&format!("\"{}\"", tracked_dir))); // Check dirs array is empty
+
+        // But the directory and user file should still exist
+        assert!(tracked_dir.is_dir());
+        assert!(tracked_dir.join("zsh_history").is_file());
+
+        Ok(())
+    }
+
+
+    #[test]
+    fn it_should_remove_nonexistent_directories_from_tracking() -> TestResult {
+        let manager = TestManager::new()?;
+        let fixture = Fixture::ExampleDot;
+        let fixture_path = manager.setup_fixture_as_git_repo(&fixture)?;
+        let home_dir = manager.home_dir();
+
+        // Add the dot
+        manager
+            .cmd(BIN)?
+            .arg("add")
+            .arg(&fixture_path)
+            .output()?;
+
+        // Switch to fixture with nested directories
+        manager.overwrite_dot(&fixture, &Fixture::ExampleDotWithNestedDirectories)?;
+
+        // Install the dot - this will create ~/.config/zsh/ directory and track it
+        manager.cmd(BIN)?.arg("install").output()?;
+
+        // Verify the directory was created and is tracked
+        let tracked_dir = home_dir.join(".config/zsh");
+        assert!(tracked_dir.is_dir());
+        let footprint = manager.read_footprint()?;
+        assert!(footprint.contains(&format!("\"{}\"", tracked_dir)));
+
+        // Switch back to basic fixture (removes nested links)
+        manager.overwrite_dot(&fixture, &Fixture::ExampleDot)?;
+
+        // User manually deletes the directory (since they no longer need it)
+        fs::remove_dir_all(&tracked_dir)?;
+        assert!(!tracked_dir.exists());
+
+        // Run install again which triggers cleanup
+        manager.cmd(BIN)?.arg("install").output()?;
+
+        // The directory should no longer be tracked since it's not needed anymore
+        let footprint = manager.read_footprint()?;
+        assert!(!footprint.contains(&format!("\"{}\"", tracked_dir)));
+
+        // And the directory should stay deleted since no symlink needs it
+        assert!(!tracked_dir.exists());
+
+        Ok(())
+    }
+
 }

--- a/tests/subcommand_list.rs
+++ b/tests/subcommand_list.rs
@@ -99,4 +99,30 @@ mod subcommand_list {
 
         Ok(())
     }
+
+    #[test]
+    fn it_should_ignore_hidden_directories_in_dots_folder() -> TestResult {
+        use std::fs;
+
+        let fixture1 = Fixture::ExampleDot;
+        let manager = TestManager::new()?;
+        let fixture1_path = manager.setup_fixture_as_git_repo(&fixture1)?;
+
+        // Add a normal dot
+        manager.cmd(BIN)?.arg("add").arg(&fixture1_path).output()?;
+
+        // Create a hidden directory in the .dots folder (like .claude)
+        let hidden_dir = manager.dots_dir().join(".claude");
+        fs::create_dir_all(&hidden_dir)?;
+
+        let output = manager.cmd(BIN)?.arg("list").output()?;
+
+        // Should only show the normal dot, not the hidden directory
+        output
+            .assert_stderr_eq("")
+            .assert_stdout_eq("example_dot")
+            .assert_success();
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary
- Track and remove extra directories during cleanup (#9)
- Fix handling of dotfiles in dots directory (#26)
- Add debug flag for verbose output (#57)
- Improve error messages with context and file paths
- Add permission testing infrastructure
- Implement action-based reconciliation system
- Add CHANGELOG.md and CONTRIBUTING.md documentation

## Changes
### Added
- Debug flag (`-d/--debug`) for verbose output
- Permission error testing infrastructure (`TestManager::make_readonly()`)
- Error context showing which operations failed and affected paths
- CHANGELOG.md documenting version history
- CONTRIBUTING.md with development and release guidelines

### Changed
- Refactored reconciliation to use action-based system
- Error messages now show full context (e.g., "Failed to update ~/.dots/dot-footprint.toml")
- Link display uses pretty paths in error messages

### Fixed
- Track and remove extra directories created during installation
- Handle dotfiles in dots directory correctly
- Display correct file paths in permission error messages
- Consistent output formatting in validation

### Internal
- Implemented `Action` enum for filesystem operations
- Added `Display` trait for `Link` with pretty path formatting
- Extended `TestManager` with permission testing capabilities

## Test Plan
- [x] All tests passing (`cargo test --all`)
- [x] No clippy warnings (`cargo clippy --all-targets`)
- [x] Code formatted (`cargo fmt --all`)
- [x] Permission error test validates error messages
- [x] Directory tracking test validates cleanup behavior